### PR TITLE
Not using render_thread with winapi implementation.

### DIFF
--- a/vcc/CMakeLists.txt
+++ b/vcc/CMakeLists.txt
@@ -107,6 +107,7 @@ if(DEFINED ANDROID_NDK)
 endif()
 
 add_library(vcc ${VCC_INCLUDES} ${VCC_SRCS})
+add_definitions(-D_ENABLE_ATOMIC_ALIGNMENT_FIX)
 generate_export_header(vcc
   BASE_NAME vcc
   EXPORT_MACRO_NAME VCC_LIBRARY


### PR DESCRIPTION
Use std::function with WndProc to use lambda captures
with windows events. Makes it possible to remove the window_data_type
with all its mutables.

The render thread is now constructed and joined inside run().