### PR TITLE
window_type cleanup.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/sample/cube/cube.cpp
+++ b/sample/cube/cube.cpp
@@ -371,7 +371,7 @@ int main(int argc, const char **argv) {
 #endif // __ANDROID__
 	vcc::window::run(window,
 		[&](VkExtent2D extent, VkFormat format,
-			std::vector<vcc::window::swapchain_type> &swapchain_images) {
+			std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
 			projection_matrix = glm::perspective(45.f,
 				float(extent.width) / extent.height, 1.f, 100.f);
 

--- a/sample/cube/cube.cpp
+++ b/sample/cube/cube.cpp
@@ -248,19 +248,13 @@ int main(int argc, const char **argv) {
 				} });
 	}
 
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-	const std::unique_ptr<xcb_connection_t, decltype(&xcb_disconnect)> connection_ptr(
-    xcb_connect(nullptr,nullptr), &xcb_disconnect);
-  auto connection(connection_ptr.get());
-  assert(!xcb_connection_has_error(connection));
-#endif // VK_USE_PLATFORM_XCB_KHR
 	vcc::window::window_type window(vcc::window::create(
 #ifdef WIN32
 		GetModuleHandle(NULL),
 #elif defined(__ANDROID__) || defined(ANDROID)
 		state,
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-		connection,
+		nullptr, nullptr,
 #endif // __ANDROID__
 		std::ref(instance), std::ref(device), std::ref(queue),
 		VkExtent2D{ 500, 500 }, VK_FORMAT_A8B8G8R8_UINT_PACK32, "Cube demo"));

--- a/sample/lighting/lighting.cpp
+++ b/sample/lighting/lighting.cpp
@@ -305,7 +305,7 @@ int main(int argc, const char **argv) {
 	return
 #endif // __ANDROID__
 	vcc::window::run(window,
-		[&](VkExtent2D extent, VkFormat format, std::vector<vcc::window::swapchain_type> &swapchain_images) {
+		[&](VkExtent2D extent, VkFormat format, std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
 			type::write(projection_matrix)[0] =
 				glm::perspective(45.f, float(extent.width) / extent.height,
 					1.f, 100.f);

--- a/sample/lighting/lighting.cpp
+++ b/sample/lighting/lighting.cpp
@@ -174,19 +174,13 @@ int main(int argc, const char **argv) {
 
 	vcc::queue::queue_type queue(vcc::queue::get_graphics_queue(
 		std::ref(device)));
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-	const std::unique_ptr<xcb_connection_t, decltype(&xcb_disconnect)> connection_ptr(
-    xcb_connect(nullptr,nullptr), &xcb_disconnect);
-  auto connection(connection_ptr.get());
-  assert(!xcb_connection_has_error(connection));
-#endif // VK_USE_PLATFORM_XCB_KHR
 	vcc::window::window_type window(vcc::window::create(
 #ifdef WIN32
 		GetModuleHandle(NULL),
 #elif defined(__ANDROID__) || defined(ANDROID)
 		state,
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-		connection,
+		nullptr, nullptr,
 #endif // __ANDROID__
 		std::ref(instance), std::ref(device), std::ref(queue),
 		VkExtent2D{ 500, 500 }, VK_FORMAT_A8B8G8R8_UINT_PACK32,

--- a/sample/normal-mapping-and-cube-texture/normal-mapping-and-cube-texture.cpp
+++ b/sample/normal-mapping-and-cube-texture/normal-mapping-and-cube-texture.cpp
@@ -464,7 +464,7 @@ int main(int argc, const char **argv) {
 	return
 #endif // __ANDROID__
 	vcc::window::run(window,
-		[&](VkExtent2D extent, VkFormat format, std::vector<vcc::window::swapchain_type> &swapchain_images) {
+		[&](VkExtent2D extent, VkFormat format, std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
 		type::write(projection_matrix)[0] = glm::perspective(45.f, float(extent.width) / extent.height, 1.f, 100.f);
 		command_buffers.clear();
 

--- a/sample/normal-mapping-and-cube-texture/normal-mapping-and-cube-texture.cpp
+++ b/sample/normal-mapping-and-cube-texture/normal-mapping-and-cube-texture.cpp
@@ -373,19 +373,13 @@ int main(int argc, const char **argv) {
 			}
 		} });
 
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-	const std::unique_ptr<xcb_connection_t, decltype(&xcb_disconnect)> connection_ptr(
-    xcb_connect(nullptr,nullptr), &xcb_disconnect);
-  auto connection(connection_ptr.get());
-  assert(!xcb_connection_has_error(connection));
-#endif // VK_USE_PLATFORM_XCB_KHR
 	vcc::window::window_type window(vcc::window::create(
 #ifdef WIN32
 		GetModuleHandle(NULL),
 #elif defined(__ANDROID__) || defined(ANDROID)
 		state,
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-		connection,
+		nullptr, nullptr,
 #endif // __ANDROID__
 		std::ref(instance), std::ref(device), std::ref(queue),
 		VkExtent2D{ 500, 500 }, VK_FORMAT_A8B8G8R8_UINT_PACK32,

--- a/sample/openvr/vr.cpp
+++ b/sample/openvr/vr.cpp
@@ -195,7 +195,7 @@ int vr_type::run(const draw_callback_type &draw_callback,
 				0.f, 0.f, 1.f, 1.f));
 
 			const vr::Texture_t texdesc = { (void*)texture.get_instance(),
-				vr::API_OpenGL, vr::ColorSpace_Gamma };
+				vr::TextureType_OpenGL, vr::ColorSpace_Gamma };
 			{
 				const vr::VRTextureBounds_t bounds = { 0.f, 0.f, .5f, 1.f };
 				compositor->Submit(vr::Eye_Left, &texdesc, &bounds);
@@ -241,8 +241,7 @@ VkExtent2D vr_type::get_recommended_render_target_size() const {
 
 glm::mat4 vr_type::get_projection_matrix(vr::Hmd_Eye nEye, float near_z,
 		float far_z) const {
-	const vr::HmdMatrix44_t mat(hmd->GetProjectionMatrix(nEye, near_z, far_z,
-		vr::API_OpenGL));
+	const vr::HmdMatrix44_t mat(hmd->GetProjectionMatrix(nEye, near_z, far_z));
 	return convert(mat);
 }
 

--- a/sample/teapot/teapot.cpp
+++ b/sample/teapot/teapot.cpp
@@ -338,19 +338,13 @@ int main(int argc, const char **argv) {
 				}
 			} });
 
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-	const std::unique_ptr<xcb_connection_t, decltype(&xcb_disconnect)> connection_ptr(
-    xcb_connect(nullptr,nullptr), &xcb_disconnect);
-  auto connection(connection_ptr.get());
-  assert(!xcb_connection_has_error(connection));
-#endif // VK_USE_PLATFORM_XCB_KHR
 	vcc::window::window_type window(vcc::window::create(
 #ifdef WIN32
 		GetModuleHandle(NULL),
 #elif defined(__ANDROID__) || defined(ANDROID)
 		state,
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
-		connection,
+		nullptr, nullptr,
 #endif // __ANDROID__
 		std::ref(instance), std::ref(device),
 		std::ref(queue), VkExtent2D{ 500, 500 },

--- a/sample/teapot/teapot.cpp
+++ b/sample/teapot/teapot.cpp
@@ -469,7 +469,7 @@ int main(int argc, const char **argv) {
 #endif // __ANDROID__
 	vcc::window::run(window,
 		[&](VkExtent2D extent, VkFormat format,
-			std::vector<vcc::window::swapchain_type> &swapchain_images) {
+			std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
 		type::write(projection_matrix)[0] = glm::perspective(
 			45.f, float(extent.width) / extent.height, 1.f, 100.f);
 		command_buffers.clear();

--- a/vcc/include/vcc/internal/raii.h
+++ b/vcc/include/vcc/internal/raii.h
@@ -24,6 +24,54 @@
 namespace vcc {
 namespace internal {
 
+template<typename T, typename Destructor>
+struct managed_type {
+	T handle;
+	Destructor destructor;
+	bool initialized;
+
+	managed_type() : initialized(false) {}
+	managed_type(T handle, Destructor &&destructor)
+		: handle(std::forward<T>(handle))
+		, destructor(std::forward<Destructor>(destructor))
+		, initialized(true) {}
+	managed_type(const managed_type<T, Destructor> &) = delete;
+	managed_type(managed_type<T, Destructor> &&copy)
+		: handle(copy.handle)
+		, destructor(std::move(copy.destructor))
+		, initialized(copy.initialized) {
+		copy.initialized = false;
+	}
+	managed_type &operator=(const managed_type<T, Destructor> &&) = delete;
+	managed_type &operator=(managed_type<T, Destructor> &&copy) {
+		destroy();
+		handle = copy.handle;
+		destructor = std::move(copy.destructor);
+		initialized = copy.initialized;
+		copy.initialized = false;
+		return *this;
+	}
+
+	~managed_type() {
+		destroy();
+	}
+
+	operator T &() {
+		return handle;
+	}
+	operator const T &() const {
+		return handle;
+	}
+
+private:
+	void destroy() {
+		if (initialized) {
+			destructor(handle);
+			initialized = false;
+		}
+	}
+};
+
 template<typename T>
 struct handle_type {
 

--- a/vcc/include/vcc/internal/raii.h
+++ b/vcc/include/vcc/internal/raii.h
@@ -30,7 +30,8 @@ struct managed_type {
 	Destructor destructor;
 	bool initialized;
 
-	managed_type() : initialized(false) {}
+	managed_type(Destructor &&destructor = Destructor())
+		: destructor(std::forward<Destructor>(destructor)), initialized(false) {}
 	managed_type(T handle, Destructor &&destructor)
 		: handle(std::forward<T>(handle))
 		, destructor(std::forward<Destructor>(destructor))

--- a/vcc/include/vcc/window.h
+++ b/vcc/include/vcc/window.h
@@ -199,7 +199,9 @@ private:
 		const type::supplier<device::device_type> &device,
 		const type::supplier<queue::queue_type> &graphics_queue)
 		: instance(instance)
-#ifdef VK_USE_PLATFORM_XCB_KHR
+#if defined(__ANDROID__)
+		, state(state)
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
 		, connection(std::forward<connection_type>(connection))
 		, window(std::forward<window_handle_type>(window))
 		, extent(extent)

--- a/vcc/src/window.cpp
+++ b/vcc/src/window.cpp
@@ -295,15 +295,14 @@ void initialize(window_type &window,
 		xcb_connection_t *connection
 #endif
 		) {
+#if defined(_WIN32)
+	window.window = window_type::window_handle_type(window_handle, &DestroyWindow);
+#endif // _WIN32
 	window.surface = vcc::surface::create(window.instance,
 #if defined(_WIN32) || defined(VK_USE_PLATFORM_XCB_KHR)
 		connection,
 #endif // _WIN32
 		window.window);
-
-#if defined(_WIN32)
-	window.window = window_type::window_handle_type(window_handle, &DestroyWindow);
-#endif // _WIN32
 
 	window.present_queue = queue::get_present_queue(window.device, window.surface);
 

--- a/vcc/src/window.cpp
+++ b/vcc/src/window.cpp
@@ -680,7 +680,7 @@ int run(window_type &window, const resize_callback_type &resize_callback,
     }
   });
 
-  VkExtent2D draw_extent;
+  VkExtent2D draw_extent{ 0, 0 };
   while (running) {
     VkExtent2D resize_extent(extent.exchange({ 0, 0 }));
     if (resize_extent.width != 0 && resize_extent.height != 0) {

--- a/vcc/src/window.cpp
+++ b/vcc/src/window.cpp
@@ -633,10 +633,12 @@ int run(window_type &window, const resize_callback_type &resize_callback,
 
 	std::atomic_bool running(true);
 	std::thread render_thread([&]() {
-	  VkExtent2D draw_extent;
+		VkExtent2D draw_extent{ 0, 0 };
 		while (running) {
 			VkExtent2D resize_extent(extent.exchange({ 0, 0 }));
-			if (resize_extent.width != 0 && resize_extent.height != 0) {
+			if (resize_extent.width != 0 && resize_extent.height != 0
+				&& (resize_extent.width != draw_extent.width
+					|| resize_extent.height != draw_extent.height)) {
 				// Android fails if there is a swapchain already, although the API
 				// gives us the possibility to hand the previous swapchain as argument
 				// when creating the new one.

--- a/vcc/src/window.cpp
+++ b/vcc/src/window.cpp
@@ -706,34 +706,30 @@ int run(window_type &window, const resize_callback_type &resize_callback,
 				// The system has asked us to save our current state.  Do so.
 				break;
 			case APP_CMD_INIT_WINDOW:
-				VCC_PRINT("APP_CMD_INIT_WINDOW");
 				// The window is being shown, get it ready.
 				if (app.window != NULL) {
 					vcc::window::initialize(window, app.window);
 					extent = { (uint32_t) ANativeWindow_getWidth(app.window),
 							   (uint32_t) ANativeWindow_getHeight(app.window) };
+					swapchain_images.clear();
+					swapchain = swapchain::swapchain_type();
 					std::tie(swapchain, swapchain_images) = resize(window, extent, resize_callback);
 				}
 				break;
 			case APP_CMD_GAINED_FOCUS:
 				running = true;
-				VCC_PRINT("APP_CMD_GAINED_FOCUS");
 				render_thread = std::thread([&]() {
 					while (running) {
 						draw(window, swapchain, swapchain_images, draw_callback, resize_callback,
 							 extent);
 					}
 				});
-				VCC_PRINT("APP_CMD_GAINED_FOCUS end");
 				break;
 			case APP_CMD_LOST_FOCUS:
-				VCC_PRINT("APP_CMD_LOST_FOCUS");
 				running = false;
 				render_thread.join();
-				VCC_PRINT("APP_CMD_LOST_FOCUS end");
 				break;
 			case APP_CMD_TERM_WINDOW:
-				VCC_PRINT("APP_CMD_TERM_WINDOW");
 				running = false;
 				if (render_thread.joinable()) {
 					render_thread.join();


### PR DESCRIPTION
No inner type in std_unique as multithreading is only done in the scope of run(). With winapi/android, lambda captures local variables in run.

Some issues with NVIDIA and xcb. Works with single threaded rendering as a last resort.