### PR TITLE
transform_type with variadic dependencies, revision counted.

### DIFF
--- a/types/include/type/storage.h
+++ b/types/include/type/storage.h
@@ -211,11 +211,6 @@ public:
 		copy.array = nullptr;
 		return *this;
 	}
-	~readable_storage_type() {
-		if (array) {
-			++internal::get_revision(*array);
-		}
-	}
 
 	const_iterator begin() const {
 		return internal::get_container(*array).cbegin();


### PR DESCRIPTION
transform can be used to merge a number of dependent arrays/primitives.

A common use case is merging projection, lookat and model matrices
whenever any of them change.

Fixes an issue where type::read causes a revision update.