### PR TITLE
Remove swapchain_image_type. swapchain images as rvalue reference.

### DIFF
--- a/sample/cube/src/cube.cpp
+++ b/sample/cube/src/cube.cpp
@@ -365,7 +365,7 @@ int main(int argc, const char **argv) {
 #endif // __ANDROID__
 	vcc::window::run(window,
 		[&](VkExtent2D extent, VkFormat format,
-			std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
+			std::vector<std::shared_ptr<vcc::image::image_type>> &&swapchain_images) {
 			projection_matrix = glm::perspective(45.f,
 				float(extent.width) / extent.height, 1.f, 100.f);
 
@@ -404,9 +404,10 @@ int main(int argc, const char **argv) {
 				auto framebuffer(vcc::framebuffer::create(std::ref(device),
 					std::ref(render_pass),
 					{
-						std::ref(vcc::window::get_image_view(swapchain_images[i])),
-						vcc::image_view::create(depth_image,{
-							VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
+						vcc::image_view::create(swapchain_images[i],
+							{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }),
+						vcc::image_view::create(depth_image,
+							{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
 					}, extent, 1));
 				vcc::command_buffer::compile(command_buffers[i], 0, VK_FALSE,
 					0, 0,

--- a/sample/heightmap/src/heightmap.cpp
+++ b/sample/heightmap/src/heightmap.cpp
@@ -364,7 +364,7 @@ int main(int argc, const char **argv) {
 #endif // __ANDROID__
 		vcc::window::run(window,
 			[&](VkExtent2D extent, VkFormat format,
-				std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
+				std::vector<std::shared_ptr<vcc::image::image_type>> &&swapchain_images) {
 		type::write(projection_matrix)[0] = glm::scale(glm::vec3(1, -1, 1))
 			* glm::perspective(45.f, float(extent.width) / extent.height,
 				near_z, far_z);
@@ -404,9 +404,10 @@ int main(int argc, const char **argv) {
 			auto framebuffer(vcc::framebuffer::create(std::ref(device),
 				std::ref(render_pass),
 				{
-					std::ref(vcc::window::get_image_view(swapchain_images[i])),
-					vcc::image_view::create(depth_image,{
-						VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
+					vcc::image_view::create(swapchain_images[i],
+						{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }),
+					vcc::image_view::create(depth_image,
+						{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
 				}, extent, 1));
 			vcc::command_buffer::compile(command_buffers[i], 0, VK_FALSE,
 				0, 0,

--- a/sample/lighting/src/lighting.cpp
+++ b/sample/lighting/src/lighting.cpp
@@ -299,7 +299,8 @@ int main(int argc, const char **argv) {
 	return
 #endif // __ANDROID__
 	vcc::window::run(window,
-		[&](VkExtent2D extent, VkFormat format, std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
+		[&](VkExtent2D extent, VkFormat format,
+				std::vector<std::shared_ptr<vcc::image::image_type>> &&swapchain_images) {
 			type::write(projection_matrix)[0] =
 				glm::perspective(45.f, float(extent.width) / extent.height,
 					1.f, 100.f);
@@ -342,8 +343,8 @@ int main(int argc, const char **argv) {
 						vcc::framebuffer::create(std::ref(device),
 							std::ref(render_pass),
 							{
-								std::ref(vcc::window::get_image_view(
-									swapchain_images[i])),
+								vcc::image_view::create(swapchain_images[i],
+									{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }),
 								vcc::image_view::create(depth_image,
 									{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
 							}, extent, 1),

--- a/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
+++ b/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
@@ -477,7 +477,7 @@ int main(int argc, const char **argv) {
 #endif // __ANDROID__
 	vcc::window::run(window,
 		[&](VkExtent2D extent, VkFormat format,
-			std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
+			std::vector<std::shared_ptr<vcc::image::image_type>> &&swapchain_images) {
 		type::write(projection_matrix)[0] = glm::perspective(
 			45.f, float(extent.width) / extent.height, 1.f, 100.f);
 		command_buffers.clear();
@@ -515,8 +515,10 @@ int main(int argc, const char **argv) {
 				vcc::command::render_pass(std::ref(render_pass),
 					vcc::framebuffer::create(std::ref(device), std::ref(render_pass),
 						{
-							std::ref(vcc::window::get_image_view(swapchain_images[i])),
-							vcc::image_view::create(depth_image, { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
+							vcc::image_view::create(swapchain_images[i],
+								{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }),
+							vcc::image_view::create(depth_image,
+								{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
 						}, extent, 1),
 					VkRect2D{ 0, 0, extent.width, extent.height },
 					{

--- a/sample/teapot/src/teapot.cpp
+++ b/sample/teapot/src/teapot.cpp
@@ -403,7 +403,7 @@ int main(int argc, const char **argv) {
 #endif // __ANDROID__
 	vcc::window::run(window,
 		[&](VkExtent2D extent, VkFormat format,
-			std::vector<vcc::window::swapchain_image_type> &swapchain_images) {
+			std::vector<std::shared_ptr<vcc::image::image_type>> &&swapchain_images) {
 		type::write(projection_matrix)[0] = glm::perspective(
 			45.f, float(extent.width) / extent.height, 1.f, 100.f);
 		command_buffers.clear();
@@ -441,8 +441,10 @@ int main(int argc, const char **argv) {
 				vcc::command::render_pass(std::ref(render_pass),
 					vcc::framebuffer::create(std::ref(device), std::ref(render_pass),
 						{
-							std::ref(vcc::window::get_image_view(swapchain_images[i])),
-							vcc::image_view::create(depth_image, { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
+							vcc::image_view::create(swapchain_images[i],
+								{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }),
+							vcc::image_view::create(depth_image,
+								{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
 						}, extent, 1),
 					VkRect2D{ 0, 0, extent.width, extent.height },
 					{

--- a/vcc/include/vcc/window.h
+++ b/vcc/include/vcc/window.h
@@ -37,35 +37,9 @@
 namespace vcc {
 namespace window {
 
-struct swapchain_image_type {
-	friend image::image_type &get_image(swapchain_image_type &swapchain);
-	friend image_view::image_view_type &get_image_view(
-		swapchain_image_type &swapchain);
-
-	swapchain_image_type() = default;
-	swapchain_image_type(const swapchain_image_type&) = delete;
-	swapchain_image_type(swapchain_image_type&&) = default;
-	swapchain_image_type &operator=(const swapchain_image_type&) = delete;
-	swapchain_image_type &operator=(swapchain_image_type&&) = default;
-
-	swapchain_image_type(const type::supplier<image::image_type> &image,
-		image_view::image_view_type &&view)
-		: image(image), view(std::forward<image_view::image_view_type>(view)) {}
-private:
-	type::supplier<image::image_type> image;
-	type::supplier<image_view::image_view_type> view;
-};
-
-inline image::image_type &get_image(swapchain_image_type &swapchain) {
-	return *swapchain.image;
-}
-
-inline image_view::image_view_type &get_image_view(swapchain_image_type &swapchain) {
-	return *swapchain.view;
-}
-
 typedef std::function<void(VkFormat)> initialize_callback_type;
-typedef std::function<void(VkExtent2D, VkFormat, std::vector<swapchain_image_type> &)> resize_callback_type;
+typedef std::function<void(VkExtent2D, VkFormat, std::vector<std::shared_ptr<image::image_type>> &&)>
+	resize_callback_type;
 typedef std::function<void(uint32_t)> draw_callback_type;
 
 enum mouse_button_type {
@@ -142,12 +116,11 @@ struct window_type {
 		xcb_connection_t *connection
 #endif
 		);
-	friend std::tuple<swapchain::swapchain_type, std::vector<swapchain_image_type>,
-		std::vector<command_buffer::command_buffer_type>,
-		std::vector<command_buffer::command_buffer_type>> resize(
-			window_type &, VkExtent2D, const resize_callback_type &);
-	friend void draw(window_type &, swapchain::swapchain_type &,
-		std::vector<swapchain_image_type> &, std::vector<command_buffer::command_buffer_type> &,
+	friend std::tuple<swapchain::swapchain_type, std::vector<command_buffer::command_buffer_type>,
+		std::vector<command_buffer::command_buffer_type>> resize(window_type &, VkExtent2D,
+			const resize_callback_type &);
+	friend void draw(window_type &window, swapchain::swapchain_type &,
+		std::vector<command_buffer::command_buffer_type> &,
 		std::vector<command_buffer::command_buffer_type> &, vcc::semaphore::semaphore_type &,
 		vcc::semaphore::semaphore_type &, vcc::semaphore::semaphore_type &,
 		const draw_callback_type &, const resize_callback_type &, VkExtent2D);

--- a/vcc/src/window.cpp
+++ b/vcc/src/window.cpp
@@ -93,8 +93,7 @@ input_callbacks_type &input_callbacks_type::set_touch_move_callback(
 const char *class_name = "vcc-vulkan";
 #endif // WIN32
 
-std::tuple<swapchain::swapchain_type, std::vector<swapchain_image_type>,
-	std::vector<command_buffer::command_buffer_type>,
+std::tuple<swapchain::swapchain_type, std::vector<command_buffer::command_buffer_type>,
 	std::vector<command_buffer::command_buffer_type>> resize(
 		window_type &window, VkExtent2D extent, const resize_callback_type &resize_callback) {
 	// Check the surface capabilities and formats
@@ -140,7 +139,7 @@ std::tuple<swapchain::swapchain_type, std::vector<swapchain_image_type>,
 			VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
 			swapchainPresentMode, VK_TRUE }));
 	std::vector<vcc::image::image_type> images(vcc::swapchain::get_images(swapchain));
-	std::vector<swapchain_image_type> swapchain_images;
+	std::vector<std::shared_ptr<vcc::image::image_type>> swapchain_images;
 	swapchain_images.reserve(images.size());
 	std::vector<command_buffer::command_buffer_type> pre_draw_commands, post_draw_commands;
 	pre_draw_commands.reserve(images.size());
@@ -169,12 +168,6 @@ std::tuple<swapchain::swapchain_type, std::vector<swapchain_image_type>,
 					}
 				}));
 		vcc::queue::submit(window.present_queue, {}, { std::ref(command_buffer) }, {});
-
-		vcc::image_view::image_view_type view(vcc::image_view::create(
-			swapchain_image, VK_IMAGE_VIEW_TYPE_2D, window.format,
-			{ VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G,
-				VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A },
-			{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }));
 
 		vcc::command_buffer::command_buffer_type pre_draw_command(std::move(
 			vcc::command_buffer::allocate(window.device, std::ref(window.cmd_pool),
@@ -215,17 +208,16 @@ std::tuple<swapchain::swapchain_type, std::vector<swapchain_image_type>,
 						{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 } }
 				}));
 
-		swapchain_images.push_back(swapchain_image_type(swapchain_image, std::move(view)));
+		swapchain_images.push_back(std::move(swapchain_image));
 		pre_draw_commands.push_back(std::move(pre_draw_command));
 		post_draw_commands.push_back(std::move(post_draw_command));
 	}
-	resize_callback(extent, window.format, swapchain_images);
-	return std::make_tuple(std::move(swapchain), std::move(swapchain_images),
-		std::move(pre_draw_commands), std::move(post_draw_commands));
+	resize_callback(extent, window.format, std::move(swapchain_images));
+	return std::make_tuple(std::move(swapchain), std::move(pre_draw_commands),
+		std::move(post_draw_commands));
 }
 
 void draw(window_type &window, swapchain::swapchain_type &swapchain,
-		std::vector<swapchain_image_type> &swapchain_images,
 		std::vector<command_buffer::command_buffer_type> &pre_draw_commands,
 		std::vector<command_buffer::command_buffer_type> &post_draw_commands,
 		vcc::semaphore::semaphore_type &image_acquired_semaphore,
@@ -242,7 +234,8 @@ void draw(window_type &window, swapchain::swapchain_type &swapchain,
 		case VK_ERROR_OUT_OF_DATE_KHR:
 			// swapchain is out of date (e.g. the window was resized) and
 			// must be recreated:
-			resize_callback(extent, window.format, swapchain_images);
+			std::tie(swapchain, pre_draw_commands, post_draw_commands) =
+				resize(window, extent, resize_callback);
 			break;
 		case VK_SUBOPTIMAL_KHR:
 			VCC_PRINT("VK_SUBOPTIMAL_KHR");
@@ -281,7 +274,8 @@ void draw(window_type &window, swapchain::swapchain_type &swapchain,
 	case VK_ERROR_OUT_OF_DATE_KHR:
 		// swapchain is out of date (e.g. the window was resized) and
 		// must be recreated:
-		resize_callback(extent, window.format, swapchain_images);
+		std::tie(swapchain, pre_draw_commands, post_draw_commands) =
+			resize(window, extent, resize_callback);
 		break;
 	case VK_SUBOPTIMAL_KHR:
 		// swapchain is not as optimal as it could be, but the platform's
@@ -585,7 +579,6 @@ int run(window_type &window, const resize_callback_type &resize_callback,
 	SetWindowLongPtr(window.window, GWLP_USERDATA, (LONG_PTR)&wnd_proc);
 
 	swapchain::swapchain_type swapchain;
-	std::vector<swapchain_image_type> swapchain_images;
 	std::vector<command_buffer::command_buffer_type> pre_draw_commands, post_draw_commands;
 	vcc::semaphore::semaphore_type image_acquired_semaphore(vcc::semaphore::create(window.device)),
 		present_semaphore(vcc::semaphore::create(window.device)),
@@ -602,11 +595,11 @@ int run(window_type &window, const resize_callback_type &resize_callback,
 				// gives us the possibility to hand the previous swapchain as argument
 				// when creating the new one.
 				swapchain = swapchain::swapchain_type();
-				std::tie(swapchain, swapchain_images, pre_draw_commands, post_draw_commands) = resize(
+				std::tie(swapchain, pre_draw_commands, post_draw_commands) = resize(
 						window, resize_extent, resize_callback);
 				draw_extent = resize_extent;
 			}
-			draw(window, swapchain, swapchain_images, pre_draw_commands, post_draw_commands,
+			draw(window, swapchain, pre_draw_commands, post_draw_commands,
 				image_acquired_semaphore, present_semaphore, draw_semaphore, draw_callback,
 				resize_callback, draw_extent);
 		}

--- a/vcc/src/window.cpp
+++ b/vcc/src/window.cpp
@@ -766,7 +766,6 @@ int run(window_type &window, const resize_callback_type &resize_callback,
 
 #elif defined(__ANDROID__)
 	swapchain::swapchain_type swapchain;
-	std::vector<swapchain_image_type> swapchain_images;
 	std::vector<command_buffer::command_buffer_type> pre_draw_commands, post_draw_commands;
 	vcc::semaphore::semaphore_type image_acquired_semaphore(vcc::semaphore::create(window.device)),
 			present_semaphore(vcc::semaphore::create(window.device)),
@@ -785,9 +784,8 @@ int run(window_type &window, const resize_callback_type &resize_callback,
 					vcc::window::initialize(window, app.window);
 					extent = { (uint32_t) ANativeWindow_getWidth(app.window),
 							   (uint32_t) ANativeWindow_getHeight(app.window) };
-					swapchain_images.clear();
 					swapchain = swapchain::swapchain_type();
-					std::tie(swapchain, swapchain_images, pre_draw_commands, post_draw_commands) =
+					std::tie(swapchain, pre_draw_commands, post_draw_commands) =
 						resize(window, extent, resize_callback);
 				}
 				break;
@@ -795,7 +793,7 @@ int run(window_type &window, const resize_callback_type &resize_callback,
 				running = true;
 				render_thread = std::thread([&]() {
 					while (running) {
-						draw(window, swapchain, swapchain_images, pre_draw_commands,
+						draw(window, swapchain, pre_draw_commands,
 							 post_draw_commands, image_acquired_semaphore, present_semaphore,
 							 draw_semaphore, draw_callback, resize_callback, extent);
 					}


### PR DESCRIPTION
Giving swapchain images as rvalue reference in window resize callback,
gives it a correct lifecycle.
Resize logic can be postponed to another thread without the dangling reference.