### PR TITLE
Made fence::wait, reset, queue::submit, present take vector of reference_wrapper

### DIFF
--- a/sample/cube/src/cube.cpp
+++ b/sample/cube/src/cube.cpp
@@ -397,7 +397,7 @@ int main(int argc, const char **argv) {
 					VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
 					depth_image, { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 } } }));
 
-			vcc::queue::submit(queue, {}, { std::ref(command_buffer) }, {});
+			vcc::queue::submit(queue, {}, { command_buffer }, {});
 			vcc::queue::wait_idle(queue);
 
 			for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
@@ -443,8 +443,7 @@ int main(int argc, const char **argv) {
 			type::write(projection_modelview_matrix)[0] = projection_matrix
 				* view_matrix * glm::rotate(angle.y, glm::vec3(1, 0, 0))
 				* glm::rotate(angle.x, glm::vec3(0, 1, 0));
-			vcc::queue::submit(queue, {},
-			{ std::ref(command_buffers[index]) }, {});
+			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/sample/heightmap/src/heightmap.cpp
+++ b/sample/heightmap/src/heightmap.cpp
@@ -397,7 +397,7 @@ int main(int argc, const char **argv) {
 				VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
 				depth_image,{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 } } }));
 
-		vcc::queue::submit(queue, {}, { std::ref(command_buffer) }, {});
+		vcc::queue::submit(queue, {}, { command_buffer }, {});
 		vcc::queue::wait_idle(queue);
 
 		for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
@@ -437,8 +437,7 @@ int main(int argc, const char **argv) {
 			* glm::vec4(0, 0, 1, 1));
 		glm::mat4 view_matrix(glm::lookAt(eye, eye + dir, glm::vec3(0, 1, 0)));
 		type::write(modelview_matrix)[0] = view_matrix;
-		vcc::queue::submit(queue, {},
-		{ std::ref(command_buffers[index]) }, {});
+		vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
 	},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/sample/lighting/src/lighting.cpp
+++ b/sample/lighting/src/lighting.cpp
@@ -330,7 +330,7 @@ int main(int argc, const char **argv) {
 						VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
 						depth_image,
 						{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 } } }));
-			vcc::queue::submit(queue, {}, { std::ref(command_buffer) }, {});
+			vcc::queue::submit(queue, {}, { command_buffer }, {});
 			vcc::queue::wait_idle(queue);
 
 			command_buffers = vcc::command_buffer::allocate(std::ref(device),
@@ -382,8 +382,7 @@ int main(int argc, const char **argv) {
 			type::write(modelview_matrix)[0] = view_matrix
 				* glm::rotate(angle.y, glm::vec3(1, 0, 0))
 				* glm::rotate(angle.x, glm::vec3(0, 1, 0));
-			vcc::queue::submit(queue, {},
-			{ std::ref(command_buffers[index]) }, {});
+			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
+++ b/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
@@ -506,8 +506,8 @@ int main(int argc, const char **argv) {
 					VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
 					depth_image, { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 } } }));
 		vcc::fence::fence_type fence(vcc::fence::create(std::ref(device)));
-		vcc::queue::submit(queue, {}, { std::ref(command_buffer) }, {}, fence);
-		vcc::fence::wait(device, { std::ref(fence) }, true);
+		vcc::queue::submit(queue, {}, { command_buffer }, {}, fence);
+		vcc::fence::wait(device, { fence }, true);
 
 		command_buffers = vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 			VK_COMMAND_BUFFER_LEVEL_PRIMARY, (uint32_t) swapchain_images.size());
@@ -549,7 +549,7 @@ int main(int argc, const char **argv) {
 			type::write(modelview_matrix_array)[0] = modelview_matrix;
 			type::write(normal_matrix_array)[0] =
 				glm::mat3(glm::transpose(glm::inverse(modelview_matrix)));
-			vcc::queue::submit(queue, {}, { std::ref(command_buffers[index]) }, {});
+			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/sample/openvr/src/openvr.cpp
+++ b/sample/openvr/src/openvr.cpp
@@ -452,7 +452,7 @@ int main(int argc, char **argv) {
 				VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
 				depth_image,{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 } } }));
 
-		vcc::queue::submit(queue, {}, { std::ref(command_buffer) }, {});
+		vcc::queue::submit(queue, {}, { command_buffer }, {});
 	}
 	vcc::queue::wait_idle(queue);
 
@@ -527,10 +527,10 @@ int main(int argc, char **argv) {
 			const glm::mat4 hmd_matrix(glm::inverse(glm::mat4(
 				mat4DevicePose[vr::k_unTrackedDeviceIndex_Hmd])));
 			update_matrix_callback(hmd_matrix, mat4DevicePose);
-			std::shared_ptr<vcc::command_buffer::command_buffer_type>
+			std::shared_ptr<const vcc::command_buffer::command_buffer_type>
 				command_buffer(shared_command_buffer);
 			if (command_buffer) {
-				vcc::queue::submit(queue, {}, { command_buffer }, {});
+				vcc::queue::submit(queue, {}, { *command_buffer }, {});
 			}
 		},
 		[&](const vr::VREvent_t &event) {

--- a/sample/openvr/src/vr.cpp
+++ b/sample/openvr/src/vr.cpp
@@ -201,11 +201,11 @@ int vr_type::run(const draw_callback_type &draw_callback,
 		type::supplier<const vcc::device::device_type> device(
 			vcc::internal::get_parent(*queue));
 
-		vcc::queue::submit(*queue, { }, { std::ref(pre_draw_command_buffer) }, {});
+		vcc::queue::submit(*queue, { }, { pre_draw_command_buffer }, {});
 
 		draw_callback(mat4DevicePose);
 
-		vcc::queue::submit(*queue, {}, { std::ref(post_draw_command_buffer) }, { });
+		vcc::queue::submit(*queue, {}, { post_draw_command_buffer }, { });
 
 		vr::VRVulkanTextureData_t texture_data{
 			uint64_t(VkImage(vcc::internal::get_instance(image))),

--- a/sample/teapot/src/teapot.cpp
+++ b/sample/teapot/src/teapot.cpp
@@ -433,8 +433,8 @@ int main(int argc, const char **argv) {
 					VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
 					depth_image, { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 } } }));
 		vcc::fence::fence_type fence(vcc::fence::create(std::ref(device)));
-		vcc::queue::submit(queue, {}, { std::ref(command_buffer) }, {}, fence);
-		vcc::fence::wait(device, { std::ref(fence) }, true);
+		vcc::queue::submit(queue, {}, { command_buffer }, {}, fence);
+		vcc::fence::wait(device, { fence }, true);
 
 		command_buffers = vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 			VK_COMMAND_BUFFER_LEVEL_PRIMARY, (uint32_t) swapchain_images.size());
@@ -490,7 +490,7 @@ int main(int argc, const char **argv) {
 						glm::mat3(glm::transpose(glm::inverse(model_view)));
 				}
 			}
-			vcc::queue::submit(queue, {}, { std::ref(command_buffers[index]) }, {});
+			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/vcc-image/src/gli_loader.cpp
+++ b/vcc-image/src/gli_loader.cpp
@@ -127,9 +127,9 @@ image::image_type gli_loader_type::load(
 						VK_QUEUE_FAMILY_IGNORED,
 						std::ref(staging_image),
 						{ aspect_mask, 0, 1, 0, 1 } } }));
-					fence::reset(*device, { std::ref(fence) });
-					queue::submit(*queue, {}, { std::ref(command_buffer) }, {}, fence);
-					fence::wait(*device, { std::ref(fence) }, true);
+					fence::reset(*device, { fence });
+					queue::submit(*queue, {}, { command_buffer }, {}, fence);
+					fence::wait(*device, { fence }, true);
 
 					copy_to_linear_image(format, aspect_mask,
 						VkExtent2D{ uint32_t(copy_extent.x), uint32_t(copy_extent.y) },
@@ -173,9 +173,9 @@ image::image_type gli_loader_type::load(
 							{ 0, 0, int32_t(z) },
 							{ uint32_t(extent.x), uint32_t(extent.y), 1 }
 					} } });
-					fence::reset(*device, { std::ref(fence) });
-					queue::submit(*queue, {}, { std::ref(command_buffer) }, {}, fence);
-					fence::wait(*device, { std::ref(fence) }, true);
+					fence::reset(*device, { fence });
+					queue::submit(*queue, {}, { command_buffer }, {}, fence);
+					fence::wait(*device, { fence }, true);
 				}
 			}
 		}

--- a/vcc-test/src/compute_shader_integration_test.cpp
+++ b/vcc-test/src/compute_shader_integration_test.cpp
@@ -140,10 +140,8 @@ TEST(ComputeShaderIntegrationTest, ComputeShaderIntegrationTest1) {
 			},
 			{}));
 	vcc::fence::fence_type fence(vcc::fence::create(std::ref(device)));
-	vcc::queue::submit(queue, {},
-		{ std::ref(command_buffer) }, {}, fence);
-	vcc::fence::wait(std::ref(device), { std::ref(fence) }, true,
-		std::chrono::nanoseconds::max());
+	vcc::queue::submit(queue, {}, { command_buffer }, {}, fence);
+	vcc::fence::wait(device, { fence }, true, std::chrono::nanoseconds::max());
 	vcc::queue::wait_idle(queue);
 
 	{

--- a/vcc/include/vcc/fence.h
+++ b/vcc/include/vcc/fence.h
@@ -47,14 +47,14 @@ VCC_LIBRARY fence_type create(
 	VkFenceCreateFlags flags = 0);
 
 VCC_LIBRARY VkResult wait(const device::device_type &device,
-		const std::vector<std::reference_wrapper<fence_type>> &fences,
+		const std::vector<std::reference_wrapper<const fence_type>> &fences,
 		bool wait_all, std::chrono::nanoseconds timeout);
 
 VkResult wait(const device::device_type &device,
-	const std::vector<std::reference_wrapper<fence_type>> &fences, bool wait_all);
+	const std::vector<std::reference_wrapper<const fence_type>> &fences, bool wait_all);
 
 VCC_LIBRARY void reset(const device::device_type &device,
-	const std::vector<type::supplier<const fence_type>> &fences);
+	const std::vector<std::reference_wrapper<const fence_type>> &fences);
 
 }  // namespace fence
 }  // namespace vcc

--- a/vcc/include/vcc/queue.h
+++ b/vcc/include/vcc/queue.h
@@ -74,20 +74,20 @@ struct wait_semaphore {
 // TODO(gardell): Support multiple submits
 VCC_LIBRARY void submit(const queue_type &queue,
 	const std::vector<wait_semaphore> &wait_semaphores,
-	const std::vector<type::supplier<const command_buffer::command_buffer_type>> &command_buffers,
-	const std::vector<type::supplier<const semaphore::semaphore_type>> &signal_semaphores,
+	const std::vector<std::reference_wrapper<const command_buffer::command_buffer_type>> &command_buffers,
+	const std::vector<std::reference_wrapper<const semaphore::semaphore_type>> &signal_semaphores,
 	const fence::fence_type &fence);
 
 VCC_LIBRARY void submit(const queue_type &queue,
 	const std::vector<wait_semaphore> &wait_semaphores,
-	const std::vector<type::supplier<const command_buffer::command_buffer_type>> &command_buffers,
-	const std::vector<type::supplier<const semaphore::semaphore_type>> &signal_semaphores);
+	const std::vector<std::reference_wrapper<const command_buffer::command_buffer_type>> &command_buffers,
+	const std::vector<std::reference_wrapper<const semaphore::semaphore_type>> &signal_semaphores);
 
 VCC_LIBRARY void wait_idle(const queue_type &queue);
 
 VCC_LIBRARY VkResult present(const queue_type &queue,
-	const std::vector<type::supplier<const semaphore::semaphore_type>> &semaphores,
-	const std::vector<type::supplier<const swapchain::swapchain_type>> &swapchains,
+	const std::vector<std::reference_wrapper<const semaphore::semaphore_type>> &semaphores,
+	const std::vector<std::reference_wrapper<const swapchain::swapchain_type>> &swapchains,
 	const std::vector<uint32_t> &image_indices);
 
 inline uint32_t get_family_index(const queue_type &queue) {

--- a/vcc/src/pipeline_layout.cpp
+++ b/vcc/src/pipeline_layout.cpp
@@ -74,9 +74,8 @@ void flush(const type::supplier<const type::serialize_type> &constants,
 		}
 		// Must block until our command finish executing.
 		fence::fence_type fence(fence::create(device));
-		queue::submit(queue, {}, { std::ref(cmd) }, {}, fence);
-		fence::wait(*device, { std::ref(fence) }, true,
-			std::chrono::nanoseconds::max());
+		queue::submit(queue, {}, { cmd }, {}, fence);
+		fence::wait(*device, { fence }, true, std::chrono::nanoseconds::max());
 	}
 }
 


### PR DESCRIPTION
reference_wrapper instead of type::supplier denotes that the functions
do not keep any references. A reminder to use fences/wait_idle before
allowing temporaries to go out of scope.