### PR TITLE
command::compile(command::build(command_buffer, args), ...)

### DIFF
--- a/sample/cube/src/cube.cpp
+++ b/sample/cube/src/cube.cpp
@@ -386,7 +386,7 @@ int main(int argc, const char **argv) {
 			vcc::command_buffer::command_buffer_type command_buffer(
 				std::move(vcc::command_buffer::allocate(std::ref(device),
 					std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-			vcc::command_buffer::compile(command_buffer, 0, VK_FALSE, 0, 0,
+			vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 				vcc::command::pipeline_barrier(
 					VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 					VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, {}, {},
@@ -409,8 +409,8 @@ int main(int argc, const char **argv) {
 						vcc::image_view::create(depth_image,
 							{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
 					}, extent, 1));
-				vcc::command_buffer::compile(command_buffers[i], 0, VK_FALSE,
-					0, 0,
+				vcc::command::compile(
+					vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
 					vcc::command::render_pass(std::ref(render_pass),
 						std::move(framebuffer), VkRect2D{ { 0, 0 }, extent },
 						{

--- a/sample/heightmap/src/heightmap.cpp
+++ b/sample/heightmap/src/heightmap.cpp
@@ -386,7 +386,7 @@ int main(int argc, const char **argv) {
 		vcc::command_buffer::command_buffer_type command_buffer(
 			std::move(vcc::command_buffer::allocate(std::ref(device),
 				std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		vcc::command_buffer::compile(command_buffer, 0, VK_FALSE, 0, 0,
+		vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 			vcc::command::pipeline_barrier(
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, {}, {},
@@ -408,7 +408,8 @@ int main(int argc, const char **argv) {
 					vcc::image_view::create(depth_image,
 						{ VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 })
 				}, extent, 1));
-			vcc::command_buffer::compile(command_buffers[i], 0, VK_FALSE, 0, 0,
+			vcc::command::compile(
+				vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
 				vcc::command::render_pass(std::ref(render_pass),
 					std::move(framebuffer), VkRect2D{ { 0, 0 }, extent },
 					{

--- a/sample/lighting/src/lighting.cpp
+++ b/sample/lighting/src/lighting.cpp
@@ -319,7 +319,7 @@ int main(int argc, const char **argv) {
 			vcc::command_buffer::command_buffer_type command_buffer(std::move(
 				vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 					VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-			vcc::command_buffer::compile(command_buffer, 0, VK_FALSE, 0, 0,
+			vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 				vcc::command::pipeline_barrier(
 					VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 					VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, {}, {},
@@ -337,9 +337,9 @@ int main(int argc, const char **argv) {
 				std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY,
 				(uint32_t) swapchain_images.size());
 			for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
-				vcc::command_buffer::compile(command_buffers[i], 0, VK_FALSE, 0, 0,
-					vcc::command::render_pass(
-						std::ref(render_pass),
+				vcc::command::compile(
+					vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
+					vcc::command::render_pass(std::ref(render_pass),
 						vcc::framebuffer::create(std::ref(device),
 							std::ref(render_pass),
 							{

--- a/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
+++ b/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
@@ -495,7 +495,7 @@ int main(int argc, const char **argv) {
 		vcc::command_buffer::command_buffer_type command_buffer(std::move(
 			vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 				VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		vcc::command_buffer::compile(command_buffer, 0, VK_FALSE, 0, 0,
+		vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 			vcc::command::pipeline_barrier(
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, {}, {},
@@ -512,7 +512,8 @@ int main(int argc, const char **argv) {
 		command_buffers = vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 			VK_COMMAND_BUFFER_LEVEL_PRIMARY, (uint32_t) swapchain_images.size());
 		for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
-			vcc::command_buffer::compile(command_buffers[i], 0, VK_FALSE, 0, 0,
+			vcc::command::compile(
+				vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
 				vcc::command::render_pass(std::ref(render_pass),
 					vcc::framebuffer::create(std::ref(device), std::ref(render_pass),
 						{

--- a/sample/openvr/src/openvr.cpp
+++ b/sample/openvr/src/openvr.cpp
@@ -213,10 +213,11 @@ instance_type load_instance(vcc::device::device_type &device,
 	vcc::command_buffer::command_buffer_type command_buffer(
 		std::move(vcc::command_buffer::allocate(std::ref(device),
 			std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_SECONDARY, 1).front()));
-	vcc::command_buffer::compile(command_buffer,
-		VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
-		| VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT,
-		std::ref(render_pass), 0, std::ref(framebuffer), VK_FALSE, 0, 0,
+	vcc::command::compile(
+		vcc::command::build(std::ref(command_buffer),
+			VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
+			| VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT,
+			std::ref(render_pass), 0, std::ref(framebuffer), VK_FALSE, 0, 0),
 		vcc::command::bind_pipeline{
 		VK_PIPELINE_BIND_POINT_GRAPHICS, std::ref(pipeline) },
 		vcc::command::bind_descriptor_sets{ VK_PIPELINE_BIND_POINT_GRAPHICS,
@@ -249,8 +250,7 @@ vcc::command_buffer::command_buffer_type recalculate_command_buffer(
 	vcc::command_buffer::command_buffer_type command_buffer(
 		std::move(vcc::command_buffer::allocate(std::ref(device),
 			std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-	vcc::command_buffer::compile(command_buffer, 0, VK_FALSE,
-		0, 0,
+	vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 		vcc::command::render_pass(std::ref(render_pass),
 			std::ref(framebuffer), VkRect2D{ { 0, 0 }, extent },
 			{
@@ -441,7 +441,7 @@ int main(int argc, char **argv) {
 		vcc::command_buffer::command_buffer_type command_buffer(
 			std::move(vcc::command_buffer::allocate(std::ref(device),
 				std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		vcc::command_buffer::compile(command_buffer, 0, VK_FALSE, 0, 0,
+		vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 			vcc::command::pipeline_barrier(
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, {}, {},

--- a/sample/openvr/src/vr.cpp
+++ b/sample/openvr/src/vr.cpp
@@ -140,8 +140,9 @@ int vr_type::run(const draw_callback_type &draw_callback,
 			vcc::internal::get_parent(*queue), std::ref(command_pool),
 			VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
 
-	vcc::command_buffer::compile(std::ref(pre_draw_command_buffer),
-		0, VK_FALSE, 0, 0, vcc::command::pipeline_barrier(
+	vcc::command::compile(
+		vcc::command::build(std::ref(pre_draw_command_buffer), 0, VK_FALSE, 0, 0),
+		vcc::command::pipeline_barrier(
 			VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 			VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, {},
 			{}, {
@@ -154,8 +155,9 @@ int vr_type::run(const draw_callback_type &draw_callback,
 					{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }
 				}
 			}));
-	vcc::command_buffer::compile(std::ref(post_draw_command_buffer),
-		0, VK_FALSE, 0, 0, vcc::command::pipeline_barrier(
+	vcc::command::compile(
+		vcc::command::build(std::ref(post_draw_command_buffer), 0, VK_FALSE, 0, 0),
+		vcc::command::pipeline_barrier(
 			VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 			VK_PIPELINE_STAGE_TRANSFER_BIT, 0, {}, {},
 			{

--- a/sample/teapot/src/teapot.cpp
+++ b/sample/teapot/src/teapot.cpp
@@ -422,7 +422,7 @@ int main(int argc, const char **argv) {
 		vcc::command_buffer::command_buffer_type command_buffer(std::move(
 			vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 				VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		vcc::command_buffer::compile(command_buffer, 0, VK_FALSE, 0, 0,
+		vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 			vcc::command::pipeline_barrier(
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, {}, {},
@@ -439,7 +439,8 @@ int main(int argc, const char **argv) {
 		command_buffers = vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 			VK_COMMAND_BUFFER_LEVEL_PRIMARY, (uint32_t) swapchain_images.size());
 		for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
-			vcc::command_buffer::compile(command_buffers[i], 0, VK_FALSE, 0, 0,
+			vcc::command::compile(
+				vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
 				vcc::command::render_pass(std::ref(render_pass),
 					vcc::framebuffer::create(std::ref(device), std::ref(render_pass),
 						{

--- a/vcc-image/src/gli_loader.cpp
+++ b/vcc-image/src/gli_loader.cpp
@@ -111,8 +111,8 @@ image::image_type gli_loader_type::load(
 						? compressed_extent(texture) : extent);
 					const std::size_t block_size(gli::block_size(texture.format()));
 
-					command_buffer::compile(command_buffer,
-						VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_FALSE, 0, 0,
+					command::compile(vcc::command::build(std::ref(command_buffer),
+							VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_FALSE, 0, 0),
 						command::pipeline_barrier(
 							VK_PIPELINE_STAGE_HOST_BIT,
 							VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
@@ -136,8 +136,8 @@ image::image_type gli_loader_type::load(
 						texture.data(layer, face, level), block_size,
 						block_size * copy_extent.x, staging_image);
 
-					command_buffer::compile(command_buffer,
-						VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_FALSE, 0, 0,
+					command::compile(vcc::command::build(std::ref(command_buffer),
+							VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_FALSE, 0, 0),
 						command::pipeline_barrier(
 							VK_PIPELINE_STAGE_HOST_BIT,
 							VK_PIPELINE_STAGE_TRANSFER_BIT, 0,

--- a/vcc-test/src/compute_shader_integration_test.cpp
+++ b/vcc-test/src/compute_shader_integration_test.cpp
@@ -121,8 +121,7 @@ TEST(ComputeShaderIntegrationTest, ComputeShaderIntegrationTest1) {
 		vcc::command_buffer::allocate(std::ref(device),
 			std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
 
-	vcc::command_buffer::compile(command_buffer, 0, VK_FALSE,
-		0, 0,
+	vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 		vcc::command::bind_pipeline{
 			VK_PIPELINE_BIND_POINT_COMPUTE, std::ref(pipeline) },
 		vcc::command::bind_descriptor_sets{

--- a/vcc/include/vcc/command_buffer.h
+++ b/vcc/include/vcc/command_buffer.h
@@ -35,6 +35,12 @@ struct queue_type;
 
 }  // namespace queue
 
+namespace command {
+
+struct build_type;
+
+}  // namespace command
+
 namespace command_buffer {
 namespace internal {
 
@@ -80,6 +86,7 @@ struct command_buffer_type
 	template<typename T>
 	friend const vcc::internal::hook_container_type<const queue::queue_type &>
 		&internal::get_pre_execute_hook(const T &value);
+	friend struct command::build_type;
 
 	command_buffer_type() = default;
 	command_buffer_type(command_buffer_type &&) = default;
@@ -100,36 +107,6 @@ VCC_LIBRARY std::vector<command_buffer_type> allocate(
 	const type::supplier<const device::device_type> &device,
 	const type::supplier<const command_pool::command_pool_type> &command_pool,
 	VkCommandBufferLevel level, uint32_t commandBufferCount);
-
-struct begin_type {
-	begin_type() = default;
-	begin_type(const begin_type &) = delete;
-	begin_type(begin_type &&) = default;
-	begin_type &operator=(const begin_type &) = delete;
-	begin_type &operator=(begin_type &&) = default;
-
-	VCC_LIBRARY ~begin_type();
-
-	explicit begin_type(const type::supplier<const command_buffer_type> &command_buffer);
-private:
-	type::supplier<const command_buffer_type> command_buffer;
-	std::unique_lock<std::mutex> command_buffer_lock;
-};
-
-VCC_LIBRARY begin_type begin(
-	const type::supplier<const command_buffer_type> &command_buffer,
-	VkCommandBufferUsageFlags flags,
-	const type::supplier<const render_pass::render_pass_type> &render_pass,
-	uint32_t subpass,
-	const type::supplier<const framebuffer::framebuffer_type> &framebuffer,
-	VkBool32 occlusionQueryEnable, VkQueryControlFlags queryFlags,
-	VkQueryPipelineStatisticFlags pipelineStatistics);
-
-VCC_LIBRARY begin_type begin(
-	const type::supplier<const command_buffer_type> &command_buffer,
-	VkCommandBufferUsageFlags flags,
-	VkBool32 occlusionQueryEnable, VkQueryControlFlags queryFlags,
-	VkQueryPipelineStatisticFlags pipelineStatistics);
 
 }  // namespace command_buffer
 }  // namespace vcc

--- a/vcc/src/command.cpp
+++ b/vcc/src/command.cpp
@@ -32,92 +32,93 @@ VkClearValue clear_depth_stencil(const VkClearDepthStencilValue &depth_stencil) 
 
 namespace internal {
 
-void cmd(cmd_args &args, const bind_pipeline &bp) {
-	VKTRACE(vkCmdBindPipeline(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const bind_pipeline &bp) {
+	VKTRACE(vkCmdBindPipeline(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		bp.pipelineBindPoint, vcc::internal::get_instance(*bp.pipeline)));
-	args.references.add(bp.pipeline);
+	internal::get_references(build).add(bp.pipeline);
 }
 
-void cmd(cmd_args &args, const set_viewport &sv) {
-	VKTRACE(vkCmdSetViewport(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const set_viewport &sv) {
+	VKTRACE(vkCmdSetViewport(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		sv.first_viewport, (uint32_t)sv.viewports.size(),
 		sv.viewports.data()));
 }
 
-void cmd(cmd_args &args, const set_scissor &ss) {
-	VKTRACE(vkCmdSetScissor(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const set_scissor &ss) {
+	VKTRACE(vkCmdSetScissor(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		ss.first_scissor, (uint32_t)ss.scissors.size(), ss.scissors.data()));
 }
 
-void cmd(cmd_args &args, const set_line_width &slw) {
-	VKTRACE(vkCmdSetLineWidth(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const set_line_width &slw) {
+	VKTRACE(vkCmdSetLineWidth(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		slw.lineWidth));
 }
 
-void cmd(cmd_args &args, const set_depth_bias &sdb) {
-	VKTRACE(vkCmdSetDepthBias(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const set_depth_bias &sdb) {
+	VKTRACE(vkCmdSetDepthBias(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		sdb.depthBiasConstantFactor, sdb.depthBiasClamp, sdb.depthBiasSlopeFactor));
 }
 
-void cmd(cmd_args &args, const set_blend_constants &sbc) {
-	VKTRACE(vkCmdSetBlendConstants(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const set_blend_constants &sbc) {
+	VKTRACE(vkCmdSetBlendConstants(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		sbc.blendConstants.data()));
 }
 
-void cmd(cmd_args &args, const set_depth_bounds &sdb) {
-	VKTRACE(vkCmdSetDepthBounds(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const set_depth_bounds &sdb) {
+	VKTRACE(vkCmdSetDepthBounds(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		sdb.minDepthBounds, sdb.maxDepthBounds));
 }
 
-void cmd(cmd_args &args, const set_stencil_compare_mask &sscm) {
+void cmd(build_type &build, const set_stencil_compare_mask &sscm) {
 	VKTRACE(vkCmdSetStencilCompareMask(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		sscm.faceMask, sscm.compareMask));
 }
 
-void cmd(cmd_args &args, const set_stencil_write_mask &sswm) {
+void cmd(build_type &build, const set_stencil_write_mask &sswm) {
 	VKTRACE(vkCmdSetStencilWriteMask(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		sswm.faceMask, sswm.writeMask));
 }
 
-void cmd(cmd_args &args, const set_stencil_reference &ssr) {
+void cmd(build_type &build, const set_stencil_reference &ssr) {
 	VKTRACE(vkCmdSetStencilReference(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		ssr.faceMask, ssr.reference));
 }
 
-void cmd(cmd_args &args, const bind_descriptor_sets &bds) {
+void cmd(build_type &build, const bind_descriptor_sets &bds) {
 	std::vector<VkDescriptorSet> descriptor_sets;
 	descriptor_sets.reserve(bds.descriptor_sets.size());
 	type::supplier<const pipeline_layout::pipeline_layout_type> layout(bds.layout);
-	args.references.add(layout);
-	args.pre_execute_callbacks.add([layout](const queue::queue_type &queue) {
+	internal::get_references(build).add(layout);
+	internal::get_pre_execute_callbacks(build).add([layout](const queue::queue_type &queue) {
 		pipeline_layout::internal::get_pre_execute_callbacks(*layout)(queue);
 	});
 	for (const type::supplier<const descriptor_set::descriptor_set_type> &descriptor_set
 			: bds.descriptor_sets) {
 		descriptor_sets.push_back(vcc::internal::get_instance(*descriptor_set));
-		args.references.add(descriptor_set);
-		args.pre_execute_callbacks.add([descriptor_set](const queue::queue_type &queue) {
+		internal::get_references(build).add(descriptor_set);
+		internal::get_pre_execute_callbacks(build).add([descriptor_set](
+				const queue::queue_type &queue) {
 			descriptor_set->pre_execute_callbacks(queue);
 		});
 	}
 	VKTRACE(vkCmdBindDescriptorSets(
-		vcc::internal::get_instance(args.buffer.get()), bds.pipelineBindPoint,
+		vcc::internal::get_instance(internal::get_command_buffer(build)), bds.pipelineBindPoint,
 		vcc::internal::get_instance(*layout), bds.firstSet,
 		(uint32_t)bds.descriptor_sets.size(), descriptor_sets.data(),
 		(uint32_t)bds.dynamic_offsets.size(), bds.dynamic_offsets.data()));
 }
 
-void cmd(cmd_args &args, const bind_index_buffer_type &bib) {
+void cmd(build_type &build, const bind_index_buffer_type &bib) {
 	VKTRACE(vkCmdBindIndexBuffer(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*bib.buffer), bib.offset, bib.indexType));
-	args.references.add(bib.buffer);
+	internal::get_references(build).add(bib.buffer);
 }
 
-void cmd(cmd_args &args, const bind_vertex_buffers_type &bvb) {
+void cmd(build_type &build, const bind_vertex_buffers_type &bvb) {
 	std::vector<VkBuffer> buffers;
 	buffers.reserve(bvb.buffers.size());
 	std::vector<VkDeviceSize> offsets;
@@ -126,173 +127,167 @@ void cmd(cmd_args &args, const bind_vertex_buffers_type &bvb) {
 	for (std::size_t i = 0; i < bvb.buffers.size(); ++i) {
 		const type::supplier<const buffer::buffer_type> &buffer(bvb.buffers[i]);
 		buffers.push_back(vcc::internal::get_instance(*buffer));
-		args.references.add(buffer);
+		internal::get_references(build).add(buffer);
 		// TODO(gardell): The bottom seem more correct when mapping multiple objects to the same target,
 		// but can't find anything in the spec.
 		offsets.push_back(bvb.offsets[i]);
 		//offsets.push_back(bvb.buffers[i]->offset + bvb.offsets[i]);
 	}
 	VKTRACE(vkCmdBindVertexBuffers(
-		vcc::internal::get_instance(args.buffer.get()), bvb.first_binding,
+		vcc::internal::get_instance(internal::get_command_buffer(build)), bvb.first_binding,
 		(uint32_t)bvb.buffers.size(), buffers.data(), offsets.data()));
 }
 
-void cmd(cmd_args &args, const draw &d) {
-	VKTRACE(vkCmdDraw(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const draw &d) {
+	VKTRACE(vkCmdDraw(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		d.vertexCount, d.instanceCount, d.firstVertex, d.firstInstance));
 }
 
-void cmd(cmd_args &args, const draw_indexed &di) {
-	VKTRACE(vkCmdDrawIndexed(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const draw_indexed &di) {
+	VKTRACE(vkCmdDrawIndexed(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		di.indexCount, di.instanceCount, di.firstIndex, di.vertexOffset,
 		di.firstInstance));
 }
 
-void cmd(cmd_args &args, const draw_indirect_type &di) {
-	VKTRACE(vkCmdDrawIndirect(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const draw_indirect_type &di) {
+	VKTRACE(vkCmdDrawIndirect(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*di.buffer), di.offset, di.drawCount,
 		di.stride));
 }
 
-void cmd(cmd_args &args, const draw_indexed_indirect_type &dii) {
+void cmd(build_type &build, const draw_indexed_indirect_type &dii) {
 	VKTRACE(vkCmdDrawIndexedIndirect(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*dii.buffer), dii.offset, dii.drawCount,
 		dii.stride));
 }
 
-void cmd(cmd_args &args, const dispatch &d) {
-	VKTRACE(vkCmdDispatch(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const dispatch &d) {
+	VKTRACE(vkCmdDispatch(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		d.x, d.y, d.z));
 }
 
-void cmd(cmd_args &args, const dispatch_indirect_type &di) {
+void cmd(build_type &build, const dispatch_indirect_type &di) {
 	VKTRACE(vkCmdDispatchIndirect(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*di.buffer), di.offset));
-	args.references.add(di.buffer);
+	internal::get_references(build).add(di.buffer);
 }
 
-void cmd(cmd_args &args, const copy_buffer_type &cb) {
+void cmd(build_type &build, const copy_buffer_type &cb) {
 	VKTRACE(vkCmdCopyBuffer(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*cb.srcBuffer),
 		vcc::internal::get_instance(*cb.dstBuffer),
 		(uint32_t)cb.regions.size(), cb.regions.data()));
-	args.references.add(cb.srcBuffer);
-	args.references.add(cb.dstBuffer);
+	internal::get_references(build).add(cb.srcBuffer, cb.dstBuffer);
 }
 
-void cmd(cmd_args &args, const copy_image &ci) {
-	VKTRACE(vkCmdCopyImage(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const copy_image &ci) {
+	VKTRACE(vkCmdCopyImage(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*ci.srcImage), ci.srcImageLayout,
 		vcc::internal::get_instance(*ci.dstImage), ci.dstImageLayout,
 		(uint32_t)ci.regions.size(), ci.regions.data()));
-	args.references.add(ci.srcImage);
-	args.references.add(ci.dstImage);
+	internal::get_references(build).add(ci.srcImage, ci.dstImage);
 }
 
-void cmd(cmd_args &args, const blit_image &bi) {
-	VKTRACE(vkCmdBlitImage(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const blit_image &bi) {
+	VKTRACE(vkCmdBlitImage(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*bi.srcImage), bi.srcImageLayout,
 		vcc::internal::get_instance(*bi.dstImage), bi.dstImageLayout,
 		(uint32_t)bi.regions.size(), bi.regions.data(), bi.filter));
-	args.references.add(bi.srcImage);
-	args.references.add(bi.dstImage);
+	internal::get_references(build).add(bi.srcImage, bi.dstImage);
 }
 
-void cmd(cmd_args &args, const copy_buffer_to_image_type &bti) {
+void cmd(build_type &build, const copy_buffer_to_image_type &bti) {
 	VKTRACE(vkCmdCopyBufferToImage(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*bti.srcBuffer),
 		vcc::internal::get_instance(*bti.dstImage), bti.dstImageLayout,
 		(uint32_t)bti.regions.size(), bti.regions.data()));
-	args.references.add(bti.srcBuffer);
-	args.references.add(bti.dstImage);
+	internal::get_references(build).add(bti.srcBuffer, bti.dstImage);
 }
 
-void cmd(cmd_args &args, const copy_image_to_buffer &cib) {
+void cmd(build_type &build, const copy_image_to_buffer &cib) {
 	VKTRACE(vkCmdCopyImageToBuffer(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*cib.srcImage), cib.srcImageLayout,
 		vcc::internal::get_instance(*cib.dstBuffer),
 		(uint32_t)cib.regions.size(), cib.regions.data()));
-	args.references.add(cib.srcImage);
-	args.references.add(cib.dstBuffer);
+	internal::get_references(build).add(cib.srcImage, cib.dstBuffer);
 }
 
-void cmd(cmd_args &args, const update_buffer &ub) {
+void cmd(build_type &build, const update_buffer &ub) {
 	VKTRACE(vkCmdUpdateBuffer(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*ub.dstBuffer), ub.dstOffset, ub.dataSize,
 		ub.pData));
-	args.references.add(ub.dstBuffer);
+	internal::get_references(build).add(ub.dstBuffer);
 }
 
-void cmd(cmd_args &args, const fill_buffer &fb) {
+void cmd(build_type &build, const fill_buffer &fb) {
 	VKTRACE(vkCmdFillBuffer(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*fb.dstBuffer), fb.dstOffset, fb.size,
 		fb.data));
-	args.references.add(fb.dstBuffer);
+	internal::get_references(build).add(fb.dstBuffer);
 }
 
-void cmd(cmd_args &args, const clear_color_image &cci) {
+void cmd(build_type &build, const clear_color_image &cci) {
 	VKTRACE(vkCmdClearColorImage(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*cci.image), cci.imageLayout, &cci.color,
 		(uint32_t)cci.ranges.size(), cci.ranges.data()));
-	args.references.add(cci.image);
+	internal::get_references(build).add(cci.image);
 }
 
-void cmd(cmd_args &args, const clear_depth_stencil_image &cdsi) {
+void cmd(build_type &build, const clear_depth_stencil_image &cdsi) {
 	VKTRACE(vkCmdClearDepthStencilImage(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*cdsi.image), cdsi.imageLayout,
 		&cdsi.pDepthStencil, (uint32_t)cdsi.ranges.size(),
 		cdsi.ranges.data()));
-	args.references.add(cdsi.image);
+	internal::get_references(build).add(cdsi.image);
 }
 
-void cmd(cmd_args &args, const clear_attachments &ca) {
+void cmd(build_type &build, const clear_attachments &ca) {
 	VKTRACE(vkCmdClearAttachments(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		(uint32_t)ca.attachments.size(), ca.attachments.data(),
 		(uint32_t)ca.rects.size(), ca.rects.data()));
 }
 
-void cmd(cmd_args &args, const resolve_image &ri) {
+void cmd(build_type &build, const resolve_image &ri) {
 	VKTRACE(vkCmdResolveImage(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*ri.srcImage), ri.srcImageLayout,
 		vcc::internal::get_instance(*ri.dstImage), ri.dstImageLayout,
 		(uint32_t)ri.regions.size(), ri.regions.data()));
-	args.references.add(ri.srcImage);
-	args.references.add(ri.dstImage);
+	internal::get_references(build).add(ri.srcImage, ri.dstImage);
 }
 
-void cmd(cmd_args &args, const set_event &se) {
+void cmd(build_type &build, const set_event &se) {
 	VKTRACE(vkCmdSetEvent(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*se.event), se.stageMask));
-	args.references.add(se.event);
+	internal::get_references(build).add(se.event);
 }
 
-void cmd(cmd_args &args, const reset_event &re) {
+void cmd(build_type &build, const reset_event &re) {
 	VKTRACE(vkCmdResetEvent(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*re.event), re.stageMask));
-	args.references.add(re.event);
+	internal::get_references(build).add(re.event);
 }
 
-void cmd(cmd_args &args, const wait_events &we) {
+void cmd(build_type &build, const wait_events &we) {
 	std::vector<VkEvent> events;
 	events.reserve(we.events.size());
 	for (const type::supplier<const event::event_type> &event : we.events) {
 		events.push_back(vcc::internal::get_instance(*event));
-		args.references.add(event);
+		internal::get_references(build).add(event);
 	}
-	VKTRACE(vkCmdWaitEvents(vcc::internal::get_instance(args.buffer.get()),
+	VKTRACE(vkCmdWaitEvents(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		(uint32_t)we.events.size(), events.data(), we.srcStageMask,
 		we.dstStageMask, (uint32_t)we.memoryBarriers.size(),
 		we.memoryBarriers.data(), (uint32_t)we.bufferMemoryBarriers.size(),
@@ -301,7 +296,7 @@ void cmd(cmd_args &args, const wait_events &we) {
 		we.imageMemoryBarriers.data()));
 }
 
-void cmd(cmd_args &args, const pipeline_barrier &pb) {
+void cmd(build_type &build, const pipeline_barrier &pb) {
 	std::vector<VkMemoryBarrier> memory_barriers;
 	memory_barriers.reserve(pb.memory_barriers.size());
 	for (const memory_barrier &barrier : pb.memory_barriers) {
@@ -331,144 +326,197 @@ void cmd(cmd_args &args, const pipeline_barrier &pb) {
 			barrier.subresourceRange });
 	}
 	VKTRACE(vkCmdPipelineBarrier(
-		vcc::internal::get_instance(args.buffer.get()), pb.srcStageMask,
+		vcc::internal::get_instance(internal::get_command_buffer(build)), pb.srcStageMask,
 		pb.dstStageMask, pb.dependencyFlags, (uint32_t)memory_barriers.size(),
 		memory_barriers.data(), (uint32_t)buffer_memory_barriers.size(),
 		buffer_memory_barriers.data(), (uint32_t)image_memory_barriers.size(),
 		image_memory_barriers.data()));
 }
 
-void cmd(cmd_args &args, const begin_query &bq) {
-	VKTRACE(vkCmdBeginQuery(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const begin_query &bq) {
+	VKTRACE(vkCmdBeginQuery(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*bq.queryPool), bq.entry, bq.flags));
-	args.references.add(bq.queryPool);
+	internal::get_references(build).add(bq.queryPool);
 }
 
-void cmd(cmd_args &args, const end_query &eq) {
-	VKTRACE(vkCmdEndQuery(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const end_query &eq) {
+	VKTRACE(vkCmdEndQuery(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*eq.queryPool), eq.entry));
-	args.references.add(eq.queryPool);
+	internal::get_references(build).add(eq.queryPool);
 }
 
-void cmd(cmd_args &args, const reset_query_pool &rqp) {
-	VKTRACE(vkCmdResetQueryPool(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const reset_query_pool &rqp) {
+	VKTRACE(vkCmdResetQueryPool(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*rqp.queryPool), rqp.firstQuery,
 		rqp.queryCount));
-	args.references.add(rqp.queryPool);
+	internal::get_references(build).add(rqp.queryPool);
 }
 
-void cmd(cmd_args &args, const write_timestamp &wt) {
-	VKTRACE(vkCmdWriteTimestamp(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const write_timestamp &wt) {
+	VKTRACE(vkCmdWriteTimestamp(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		wt.pipelineStage, vcc::internal::get_instance(*wt.queryPool),
 		wt.entry));
-	args.references.add(wt.queryPool);
+	internal::get_references(build).add(wt.queryPool);
 }
 
-void cmd(cmd_args &args, const copy_query_pool_results &cqpr) {
+void cmd(build_type &build, const copy_query_pool_results &cqpr) {
 	VKTRACE(vkCmdCopyQueryPoolResults(
-		vcc::internal::get_instance(args.buffer.get()),
+		vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*cqpr.queryPool), cqpr.firstQuery,
 		cqpr.queryCount, vcc::internal::get_instance(*cqpr.dstBuffer),
 		cqpr.dstOffset, cqpr.stride, cqpr.flags));
-	args.references.add(cqpr.queryPool);
-	args.references.add(cqpr.dstBuffer);
+	internal::get_references(build).add(cqpr.queryPool, cqpr.dstBuffer);
 }
 
-void cmd(cmd_args &args, const push_constants_type &pc) {
-	VKTRACE(vkCmdPushConstants(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const push_constants_type &pc) {
+	VKTRACE(vkCmdPushConstants(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		vcc::internal::get_instance(*pc.layout), pc.stageFlags, pc.offset,
 		pc.size, pc.pValues));
-	args.references.add(pc.layout);
+	internal::get_references(build).add(pc.layout);
 }
 
-void cmd(cmd_args &args, const next_subpass &ns) {
-	VKTRACE(vkCmdNextSubpass(vcc::internal::get_instance(args.buffer.get()),
+void cmd(build_type &build, const next_subpass &ns) {
+	VKTRACE(vkCmdNextSubpass(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		ns.contents));
 }
 
-void cmd(cmd_args &args, const execute_commands &ec) {
+void cmd(build_type &build, const execute_commands &ec) {
 	std::vector<VkCommandBuffer> command_buffers;
 	command_buffers.reserve(ec.commandBuffers.size());
 	for (const type::supplier<const command_buffer::command_buffer_type> &command
 			: ec.commandBuffers) {
 		command_buffers.push_back(vcc::internal::get_instance(*command));
-		args.references.add(command);
-		args.pre_execute_callbacks.add([command](const queue::queue_type &queue) {
+		internal::get_references(build).add(command);
+		internal::get_pre_execute_callbacks(build).add([command](const queue::queue_type &queue) {
 			command_buffer::internal::get_pre_execute_hook(*command)(queue);
 		});
 	}
-	VKTRACE(vkCmdExecuteCommands(vcc::internal::get_instance(args.buffer.get()),
+	VKTRACE(vkCmdExecuteCommands(vcc::internal::get_instance(internal::get_command_buffer(build)),
 		(uint32_t) command_buffers.size(), command_buffers.data()));
 }
 
-void cmd(cmd_args &args, const bind_index_data_buffer_type&bidb) {
+void cmd(build_type &build, const bind_index_data_buffer_type&bidb) {
 	const type::supplier<const input_buffer::input_buffer_type> &buffer(bidb.buffer);
-	args.pre_execute_callbacks.add([buffer](const queue::queue_type &queue) {
+	internal::get_pre_execute_callbacks(build).add([buffer](const queue::queue_type &queue) {
 		input_buffer::flush(queue, *buffer);
 	});
-	cmd(args, bind_index_buffer_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
+	cmd(build, bind_index_buffer_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
 		bidb.offset, bidb.indexType });
 }
 
-void cmd(cmd_args &args, const bind_vertex_data_buffers_type&bvdb) {
+void cmd(build_type &build, const bind_vertex_data_buffers_type&bvdb) {
 	std::vector<type::supplier<const buffer::buffer_type>> buffers;
 	buffers.reserve(bvdb.buffers.size());
 	for (const type::supplier<const input_buffer::input_buffer_type> &buffer : bvdb.buffers) {
-		args.pre_execute_callbacks.add([buffer](const queue::queue_type &queue) {
+		internal::get_pre_execute_callbacks(build).add([buffer](const queue::queue_type &queue) {
 			input_buffer::flush(queue, *buffer);
 		});
 		buffers.push_back(std::ref(input_buffer::internal::get_buffer(*buffer)));
 	}
-	cmd(args, bind_vertex_buffers_type{ bvdb.first_binding, std::move(buffers),
+	cmd(build, bind_vertex_buffers_type{ bvdb.first_binding, std::move(buffers),
 		bvdb.offsets });
 }
 
-void cmd(cmd_args &args, const draw_indirect_data_type&did) {
+void cmd(build_type &build, const draw_indirect_data_type&did) {
 	const type::supplier<const input_buffer::input_buffer_type> &buffer(did.buffer);
-	args.pre_execute_callbacks.add([buffer](const queue::queue_type &queue) {
+	internal::get_pre_execute_callbacks(build).add([buffer](const queue::queue_type &queue) {
 		input_buffer::flush(queue, *buffer);
 	});
-	cmd(args, draw_indirect_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
+	cmd(build, draw_indirect_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
 		did.offset, did.drawCount, did.stride });
 }
 
-void cmd(cmd_args &args, const draw_indexed_indirect_data_type&diid) {
+void cmd(build_type &build, const draw_indexed_indirect_data_type&diid) {
 	const type::supplier<const input_buffer::input_buffer_type> &buffer(diid.buffer);
-	args.pre_execute_callbacks.add([buffer](const queue::queue_type &queue) {
+	internal::get_pre_execute_callbacks(build).add([buffer](const queue::queue_type &queue) {
 		input_buffer::flush(queue, *buffer);
 	});
-	cmd(args, draw_indexed_indirect_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
+	cmd(build, draw_indexed_indirect_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
 		diid.offset, diid.drawCount, diid.stride });
 }
 
-void cmd(cmd_args &args, const dispatch_indirect_data_type&did) {
+void cmd(build_type &build, const dispatch_indirect_data_type&did) {
 	const type::supplier<const input_buffer::input_buffer_type> &buffer(did.buffer);
-	args.pre_execute_callbacks.add([buffer](const queue::queue_type &queue) {
+	internal::get_pre_execute_callbacks(build).add([buffer](const queue::queue_type &queue) {
 		input_buffer::flush(queue, *buffer);
 	});
-	cmd(args, dispatch_indirect_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
+	cmd(build, dispatch_indirect_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
 		did.offset });
 }
 
-void cmd(cmd_args &args, const copy_data_buffer_type&cdb) {
+void cmd(build_type &build, const copy_data_buffer_type&cdb) {
 	const type::supplier<const input_buffer::input_buffer_type> &buffer(cdb.srcBuffer);
-	args.pre_execute_callbacks.add([buffer](const queue::queue_type &queue) {
+	internal::get_pre_execute_callbacks(build).add([buffer](const queue::queue_type &queue) {
 		input_buffer::flush(queue, *buffer);
 	});
-	cmd(args, copy_buffer_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
+	cmd(build, copy_buffer_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
 		cdb.dstBuffer, cdb.regions });
 }
 
-void cmd(cmd_args &args, const copy_data_buffer_to_image_type&cdbti) {
+void cmd(build_type &build, const copy_data_buffer_to_image_type&cdbti) {
 	const type::supplier<const input_buffer::input_buffer_type> &buffer(cdbti.srcBuffer);
-	args.pre_execute_callbacks.add([buffer](const queue::queue_type &queue) {
+	internal::get_pre_execute_callbacks(build).add([buffer](const queue::queue_type &queue) {
 		input_buffer::flush(queue, *buffer);
 	});
-	cmd(args, copy_buffer_to_image_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
+	cmd(build, copy_buffer_to_image_type{ std::ref(input_buffer::internal::get_buffer(*buffer)),
 		cdbti.dstImage, cdbti.dstImageLayout, cdbti.regions });
 }
 
 }  // namespace internal
+
+build_type::~build_type() {
+	if (command_buffer) {
+		VKCHECK(vkEndCommandBuffer(vcc::internal::get_instance(*command_buffer)));
+		command_buffer->references = std::move(references);
+		command_buffer->pre_execute_hook = std::move(pre_execute_callbacks);
+	}
+}
+
+build_type::build_type(const type::supplier<command_buffer::command_buffer_type> &command_buffer)
+	: command_buffer(command_buffer),
+	command_buffer_lock(vcc::internal::get_mutex(*command_buffer)) {}
+
+build_type build(const type::supplier<command_buffer::command_buffer_type> &command_buffer,
+	VkCommandBufferUsageFlags flags,
+	const type::supplier<const render_pass::render_pass_type> &render_pass,
+	uint32_t subpass,
+	const type::supplier<const framebuffer::framebuffer_type> &framebuffer,
+	VkBool32 occlusionQueryEnable, VkQueryControlFlags queryFlags,
+	VkQueryPipelineStatisticFlags pipelineStatistics) {
+	VkCommandBufferInheritanceInfo inheritance_info = {
+		VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, NULL };
+	inheritance_info.renderPass = VkRenderPass(vcc::internal::get_instance(*render_pass));
+	inheritance_info.subpass = subpass;
+	inheritance_info.framebuffer = VkFramebuffer(vcc::internal::get_instance(*framebuffer));
+	inheritance_info.occlusionQueryEnable = occlusionQueryEnable;
+	inheritance_info.queryFlags = queryFlags;
+	inheritance_info.pipelineStatistics = pipelineStatistics;
+	VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL };
+	info.flags = flags;
+	info.pInheritanceInfo = &inheritance_info;
+	VKCHECK(vkBeginCommandBuffer(vcc::internal::get_instance(*command_buffer), &info));
+	build_type begin(command_buffer);
+	internal::get_references(begin).add(render_pass, framebuffer);
+	return begin;
+}
+
+build_type build(const type::supplier<command_buffer::command_buffer_type> &command_buffer,
+	VkCommandBufferUsageFlags flags, VkBool32 occlusionQueryEnable,
+	VkQueryControlFlags queryFlags, VkQueryPipelineStatisticFlags pipelineStatistics) {
+	VkCommandBufferInheritanceInfo inheritance_info =
+		{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, NULL };
+	inheritance_info.renderPass = VK_NULL_HANDLE;
+	inheritance_info.subpass = 0;
+	inheritance_info.framebuffer = VK_NULL_HANDLE;
+	inheritance_info.occlusionQueryEnable = occlusionQueryEnable;
+	inheritance_info.queryFlags = queryFlags;
+	inheritance_info.pipelineStatistics = pipelineStatistics;
+	VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL };
+	info.flags = flags;
+	info.pInheritanceInfo = &inheritance_info;
+	VKCHECK(vkBeginCommandBuffer(vcc::internal::get_instance(*command_buffer), &info));
+	return build_type(command_buffer);
+}
 
 }  // namespace command
 }  // namespace vcc

--- a/vcc/src/command_buffer.cpp
+++ b/vcc/src/command_buffer.cpp
@@ -44,57 +44,6 @@ std::vector<command_buffer_type> allocate(
 	return std::move(command_buffers);
 }
 
-begin_type::~begin_type() {
-	if (command_buffer) {
-		VKCHECK(vkEndCommandBuffer(
-			vcc::internal::get_instance(*command_buffer)));
-	}
-}
-
-begin_type::begin_type(
-	const type::supplier<const command_buffer_type> &command_buffer)
-	: command_buffer(command_buffer),
-	  command_buffer_lock(vcc::internal::get_mutex(*command_buffer)) {}
-
-begin_type begin(const type::supplier<const command_buffer_type> &command_buffer,
-	VkCommandBufferUsageFlags flags,
-	const type::supplier<const render_pass::render_pass_type> &render_pass,
-	uint32_t subpass,
-	const type::supplier<const framebuffer::framebuffer_type> &framebuffer,
-	VkBool32 occlusionQueryEnable, VkQueryControlFlags queryFlags,
-	VkQueryPipelineStatisticFlags pipelineStatistics) {
-	VkCommandBufferInheritanceInfo inheritance_info = {
-		VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, NULL };
-	inheritance_info.renderPass = VkRenderPass(vcc::internal::get_instance(*render_pass));
-	inheritance_info.subpass = subpass;
-	inheritance_info.framebuffer = VkFramebuffer(vcc::internal::get_instance(*framebuffer));
-	inheritance_info.occlusionQueryEnable = occlusionQueryEnable;
-	inheritance_info.queryFlags = queryFlags;
-	inheritance_info.pipelineStatistics = pipelineStatistics;
-	VkCommandBufferBeginInfo info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL};
-	info.flags = flags;
-	info.pInheritanceInfo = &inheritance_info;
-	VKCHECK(vkBeginCommandBuffer(vcc::internal::get_instance(*command_buffer), &info));
-	return begin_type(command_buffer);
-}
-
-begin_type begin(const type::supplier<const command_buffer_type> &command_buffer,
-		VkCommandBufferUsageFlags flags, VkBool32 occlusionQueryEnable,
-		VkQueryControlFlags queryFlags, VkQueryPipelineStatisticFlags pipelineStatistics) {
-	VkCommandBufferInheritanceInfo inheritance_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, NULL };
-	inheritance_info.renderPass = VK_NULL_HANDLE;
-	inheritance_info.subpass = 0;
-	inheritance_info.framebuffer = VK_NULL_HANDLE;
-	inheritance_info.occlusionQueryEnable = occlusionQueryEnable;
-	inheritance_info.queryFlags = queryFlags;
-	inheritance_info.pipelineStatistics = pipelineStatistics;
-	VkCommandBufferBeginInfo info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, NULL };
-	info.flags = flags;
-	info.pInheritanceInfo = &inheritance_info;
-	VKCHECK(vkBeginCommandBuffer(vcc::internal::get_instance(*command_buffer), &info));
-	return begin_type(command_buffer);
-}
-
 }  // namespace command_buffer
 }  // namespace vcc
 

--- a/vcc/src/input_buffer.cpp
+++ b/vcc/src/input_buffer.cpp
@@ -48,8 +48,9 @@ bool flush(const queue::queue_type &queue, const input_buffer_type &buffer) {
 			VK_COMMAND_POOL_CREATE_TRANSIENT_BIT, queue::get_family_index(queue)));
 		command_buffer::command_buffer_type cmd(std::move(command_buffer::allocate(device,
 			std::ref(command_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		command_buffer::compile(cmd, VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
-			VK_FALSE, 0, 0,
+		command::compile(
+			vcc::command::build(std::ref(cmd), VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+				VK_FALSE, 0, 0),
 			command::pipeline_barrier{ VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
 				VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
 				{},

--- a/vcc/src/pipeline_layout.cpp
+++ b/vcc/src/pipeline_layout.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cassert>
 #include <iterator>
+#include <vcc/command.h>
 #include <vcc/command_buffer.h>
 #include <vcc/queue.h>
 #include <vcc/pipeline_layout.h>
@@ -62,7 +63,7 @@ void flush(const type::supplier<const type::serialize_type> &constants,
 			command_buffer::allocate(device, std::ref(command_pool),
 				VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
 		{
-			command_buffer::begin_type begin(command_buffer::begin(
+			command::build_type begin(command::build(
 				std::ref(cmd), VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
 				VK_FALSE, 0, 0));
 			for (const VkPushConstantRange &range : push_constant_ranges) {

--- a/vcc/src/window.cpp
+++ b/vcc/src/window.cpp
@@ -157,7 +157,7 @@ std::tuple<swapchain::swapchain_type, std::vector<command_buffer::command_buffer
 		vcc::command_buffer::command_buffer_type command_buffer(std::move(
 		  vcc::command_buffer::allocate(window.device, std::ref(window.cmd_pool),
 			  VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		vcc::command_buffer::compile(command_buffer, 0, VK_FALSE, 0, 0,
+		vcc::command::compile(vcc::command::build(std::ref(command_buffer), 0, VK_FALSE, 0, 0),
 			vcc::command::pipeline_barrier(
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
 				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, {}, {},
@@ -176,7 +176,7 @@ std::tuple<swapchain::swapchain_type, std::vector<command_buffer::command_buffer
 		vcc::command_buffer::command_buffer_type pre_draw_command(std::move(
 			vcc::command_buffer::allocate(window.device, std::ref(window.cmd_pool),
 				VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		vcc::command_buffer::compile(pre_draw_command, 0, VK_FALSE, 0, 0,
+		vcc::command::compile(vcc::command::build(std::ref(pre_draw_command), 0, VK_FALSE, 0, 0),
 			vcc::command::pipeline_barrier(
 				VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 				VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, {}, {},
@@ -196,7 +196,7 @@ std::tuple<swapchain::swapchain_type, std::vector<command_buffer::command_buffer
 		vcc::command_buffer::command_buffer_type post_draw_command(std::move(
 			vcc::command_buffer::allocate(window.device, std::ref(window.cmd_pool),
 				VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1).front()));
-		vcc::command_buffer::compile(post_draw_command, 0, VK_FALSE, 0, 0,
+		vcc::command::compile(vcc::command::build(std::ref(post_draw_command), 0, VK_FALSE, 0, 0),
 			vcc::command::pipeline_barrier(
 				VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
 				VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, {}, {},


### PR DESCRIPTION
Separated command::compile into RAII style object and function.
instead of
command::compile(command_buffer, args, commands...)
now
command::compile(command::build(command_buffer, args), ...)
or
auto builder(command::build(command_buffer, args))
command::compile(builder, ...)
command::compile(builder, ...)
command::compile(builder, ...)

which allows conditionals/loops of commands.