### PR TITLE
Added support for custom types and std::tuple, std::array.

### DIFF
--- a/sample/lighting/src/lighting.cpp
+++ b/sample/lighting/src/lighting.cpp
@@ -107,30 +107,28 @@ int main(int argc, const char **argv) {
 			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE, {},
 			std::ref(projection_matrix), std::ref(modelview_matrix), std::ref(normal_matrix)));
 
-	struct {
-		type::vec4 position;
-		type::vec3 attenuation;
-		type::vec3 spot_direction;
-		type::float_type spot_cos_cutoff;
-		type::vec4 ambient;
-		type::vec4 diffuse;
-		type::vec4 specular;
-		type::float_type spot_exponent;
-	} light{
-		type::vec4(glm::vec4(0.f, 10.f, 0.f, 1.f)),
-		type::vec3(glm::vec3(1, 0, 0)), type::vec3(glm::vec3(0, 0, -1)),
-		type::float_type(-1), type::vec4(glm::vec4(0.2f, 0.2f, 0.2f, 1)),
-		type::vec4(glm::vec4(0.9f, 0.9f, 0.9f, 1.f)),
-		type::vec4(glm::vec4(1.f, 1.f, 1.f, 1.f)), type::float_type(120.f)
-	};
+	struct light_type {
+		glm::vec4 position;
+		glm::vec3 attenuation, spot_direction;
+		float spot_cos_cutoff;
+		glm::vec4 ambient, diffuse, specular;
+		float spot_exponent;
 
+		VCC_STRUCT_SERIALIZABLE(position, attenuation, spot_direction, spot_cos_cutoff, ambient,
+			diffuse, specular, spot_exponent);
+	};
+	type::t_array<light_type> lights{ {
+		{ 0, 10, 0, 1 },
+		{ 1, 0, 0 },
+		{ 0, 0, -1 },
+		-1,
+		{ .2f, .2f, .2f, 1 },
+		{ .9f, .9f, .9f, 1 },
+		{ 1, 1, 1, 1 },
+		120 } };
 	vcc::input_buffer::input_buffer_type light_uniform_buffer(
 		vcc::input_buffer::create<type::linear_std140>(std::ref(device), 0,
-			VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE, {},
-			std::ref(light.position), std::ref(light.attenuation),
-			std::ref(light.spot_direction), std::ref(light.spot_cos_cutoff),
-			std::ref(light.ambient), std::ref(light.diffuse),
-			std::ref(light.specular), std::ref(light.spot_exponent)));
+		VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE, {}, std::ref(lights)));
 
 	vcc::input_buffer::input_buffer_type vertex_buffer(
 		vcc::input_buffer::create<type::interleaved_std140>(std::ref(device), 0,

--- a/types/include/type/serialize.h
+++ b/types/include/type/serialize.h
@@ -27,7 +27,7 @@ namespace internal {
 
 template<memory_layout Layout, std::size_t I>
 struct layout_type {
-	constexpr static memory_layout memory_layout = Layout;
+	constexpr static memory_layout layout = Layout;
 	typedef std::array<std::size_t, I> indices_type;
 	indices_type offset, stride;
 	std::size_t size;
@@ -128,7 +128,7 @@ struct serialize_storage_type {
 	template<typename Layout, typename Storages>
 	static void serialize(const Layout &layout, const Storages &storages, void *target) {
 		constexpr std::size_t index = I - 1;
-		internal::serialize<Layout::memory_layout>(*std::get<index>(storages),
+		internal::serialize<Layout::layout>(*std::get<index>(storages),
 			std::get<index>(layout.offset), std::get<index>(layout.stride), target);
 		serialize_storage_type<index>::serialize(layout, storages, target);
 	}

--- a/types/include/type/types.h
+++ b/types/include/type/types.h
@@ -283,6 +283,28 @@ namespace internal {
 	template<> struct primitive_type_information<glm::bvec4>
 		: glm_vec_type_information<glm::bvec4, sizeof(bool) * 4> {};
 
+	// TODO(gardell): Write test!
+	// TODO(gardell): Alignment is dependent on std140/std430!
+	template<typename T, std::size_t Size>
+	struct primitive_type_information<std::array<T, Size>> {
+		constexpr static std::size_t alignment = primitive_type_information<T>::alignment,
+			element_size = primitive_type_information<T>::size,
+			size = Size * alignment;
+
+		static void copy(const T &value, void *target) {
+			uint8_t *bytes(reinterpret_cast<uint8_t *>(target));
+			for (std::size_t column = 0; column < Size; ++column) {
+				std::memcpy(bytes, glm::value_ptr(value[column]), element_size);
+				bytes += alignment;
+			}
+		}
+	};
+
+	template<typename... Ts>
+	struct primitive_type_information<std::tuple<Ts...>> {
+
+	};
+
 	template<typename T, std::size_t Size, std::size_t Alignment, std::size_t Columns>
 	struct glm_mat_type_information {
 
@@ -296,6 +318,7 @@ namespace internal {
 			}
 		}
 	};
+
 	template<typename T, std::size_t Size, std::size_t Alignment, std::size_t Columns>
 	constexpr std::size_t glm_mat_type_information<T, Size, Alignment, Columns>::size;
 	template<typename T, std::size_t Size, std::size_t Alignment, std::size_t Columns>


### PR DESCRIPTION
With this change, a C++ ```struct``` can be used to match a
SPIR-V/GLSL ```struct```. The following GLSL code:

```GLSL
struct light_type {
  vec4 position;
  vec3 attenuation;
  vec3 spot_direction;
  float spot_cos_cutoff;
  vec4 ambient;
  vec4 diffuse;
  vec4 specular;
  float spot_exponent;
};

layout(std140, binding = 1) uniform lights {
        light_type lights[max_lights];
} lightsbuf;
```

can be matched with the following host/C++ code:

```C++
struct light_type {
  vec4 position;
  vec3 attenuation;
  vec3 spot_direction;
  float spot_cos_cutoff;
  vec4 ambient;
  vec4 diffuse;
  vec4 specular;
  float spot_exponent;

  VCC_STRUCT_SERIALIZABLE(position, attenuation, spot_direction,
    spot_cos_cutoff, ambient, diffuse, specular, spot_exponent);
};
t_array<light_type> lights(max_lights);

auto light_uniform_buffer(input_buffer::create<linear_std140>(
  std::ref(device), 0, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
  VK_SHARING_MODE_EXCLUSIVE, {}, std::ref(lights)));
```
```std140``` and ```std430``` layouts are supported.

The ```VCC_STRUCT_SERIALIZABLE``` declare the method ```vcc_serialize()``` which returns ```std::tie(...)``` of the arguments passed to the macro. Instead of custom structs, ```std::tuple``` and ```std::array``` types can also be used.

See sample/lighting for an example.