### PR TITLE
Removed pre/post_draw_commands from vcc::window.

### DIFF
--- a/sample/cube/src/cube.cpp
+++ b/sample/cube/src/cube.cpp
@@ -398,6 +398,8 @@ int main(int argc, const char **argv) {
 			vcc::queue::submit(queue, {}, { command_buffer }, {});
 			vcc::queue::wait_idle(queue);
 
+			const vcc::queue::queue_type &present_queue(vcc::window::get_present_queue(window));
+
 			for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
 				auto framebuffer(vcc::framebuffer::create(std::ref(device), std::ref(render_pass),
 					{
@@ -408,6 +410,21 @@ int main(int argc, const char **argv) {
 					}, extent, 1));
 				vcc::command::compile(
 					vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
+					vcc::command::pipeline_barrier(
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, {}, {},
+						{
+							vcc::command::image_memory_barrier{ 0,
+								VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
+								| VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+								VK_IMAGE_LAYOUT_UNDEFINED,
+								VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+								vcc::queue::get_family_index(present_queue),
+								vcc::queue::get_family_index(queue),
+								swapchain_images[i],
+								{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }
+							}
+						}),
 					vcc::command::render_pass(std::ref(render_pass),
 						std::move(framebuffer), VkRect2D{ { 0, 0 }, extent },
 						{
@@ -430,17 +447,36 @@ int main(int argc, const char **argv) {
 						vcc::command::set_scissor{
 							0, { { { 0, 0 }, extent } } },
 						vcc::command::draw_indexed{
-							(uint32_t)indices.size(), 1, 0, 0, 0 }));
+							(uint32_t)indices.size(), 1, 0, 0, 0 }),
+					vcc::command::pipeline_barrier(
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+						VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, {}, {},
+						{
+							vcc::command::image_memory_barrier{
+								VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+								0,
+								VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+								VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+								vcc::queue::get_family_index(queue),
+								vcc::queue::get_family_index(present_queue),
+								swapchain_images[i],
+								{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 } }
+						}));
 			}
 		},
 		[]() {},
-		[&](uint32_t index) {
+		[&](uint32_t index, const vcc::semaphore::semaphore_type &wait_semaphore,
+				const vcc::semaphore::semaphore_type &signal_semaphore) {
 			glm::mat4 view_matrix(glm::lookAt(glm::vec3(0, 0, camera_distance),
 				glm::vec3(0, 0, 0), glm::vec3(0, 1, 0)));
 			type::write(projection_modelview_matrix)[0] = projection_matrix
 				* view_matrix * glm::rotate(angle.y, glm::vec3(1, 0, 0))
 				* glm::rotate(angle.x, glm::vec3(0, 1, 0));
-			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
+			vcc::queue::submit(queue,
+				{
+					vcc::queue::wait_semaphore{ std::ref(wait_semaphore),
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT }
+				}, { command_buffers[index] }, { signal_semaphore });
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/sample/lighting/src/lighting.cpp
+++ b/sample/lighting/src/lighting.cpp
@@ -330,12 +330,29 @@ int main(int argc, const char **argv) {
 			vcc::queue::submit(queue, {}, { command_buffer }, {});
 			vcc::queue::wait_idle(queue);
 
+			const vcc::queue::queue_type &present_queue(vcc::window::get_present_queue(window));
+
 			command_buffers = vcc::command_buffer::allocate(std::ref(device),
 				std::ref(cmd_pool), VK_COMMAND_BUFFER_LEVEL_PRIMARY,
 				(uint32_t) swapchain_images.size());
 			for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
 				vcc::command::compile(
 					vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
+					vcc::command::pipeline_barrier(
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, {}, {},
+						{
+							vcc::command::image_memory_barrier{ 0,
+								VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
+								| VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+								VK_IMAGE_LAYOUT_UNDEFINED,
+								VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+								vcc::queue::get_family_index(present_queue),
+								vcc::queue::get_family_index(queue),
+								swapchain_images[i],
+								{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }
+							}
+						}),
 					vcc::command::render_pass(std::ref(render_pass),
 						vcc::framebuffer::create(std::ref(device),
 							std::ref(render_pass),
@@ -369,17 +386,36 @@ int main(int argc, const char **argv) {
 						vcc::command::set_scissor{ 0,{ VkRect2D{
 							VkOffset2D{ 0, 0 }, extent } } },
 						vcc::command::draw_indexed{
-							(uint32_t)teapot::indices.size(), 1, 0, 0, 0 }));
+							(uint32_t)teapot::indices.size(), 1, 0, 0, 0 }),
+					vcc::command::pipeline_barrier(
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+						VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, {}, {},
+						{
+							vcc::command::image_memory_barrier{
+								VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+								0,
+								VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+								VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+								vcc::queue::get_family_index(queue),
+								vcc::queue::get_family_index(present_queue),
+								swapchain_images[i],
+								{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 } }
+						}));
 			}
 		},
 		[]() {},
-		[&](uint32_t index) {
+		[&](uint32_t index, const vcc::semaphore::semaphore_type &wait_semaphore,
+				const vcc::semaphore::semaphore_type &signal_semaphore) {
 			glm::mat4 view_matrix(glm::lookAt(glm::vec3(0, 0, camera_distance),
 				glm::vec3(0, 0, 0), glm::vec3(0, 1, 0)));
 			type::write(modelview_matrix)[0] = view_matrix
 				* glm::rotate(angle.y, glm::vec3(1, 0, 0))
 				* glm::rotate(angle.x, glm::vec3(0, 1, 0));
-			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
+			vcc::queue::submit(queue,
+				{
+					vcc::queue::wait_semaphore{ std::ref(wait_semaphore),
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT }
+				}, { command_buffers[index] }, { signal_semaphore });
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
+++ b/sample/normal-mapping-and-cube-texture/src/normal-mapping-and-cube-texture.cpp
@@ -500,11 +500,28 @@ int main(int argc, const char **argv) {
 		vcc::queue::submit(queue, {}, { command_buffer }, {}, fence);
 		vcc::fence::wait(device, { fence }, true);
 
+		const vcc::queue::queue_type &present_queue(vcc::window::get_present_queue(window));
+
 		command_buffers = vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 			VK_COMMAND_BUFFER_LEVEL_PRIMARY, (uint32_t) swapchain_images.size());
 		for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
 			vcc::command::compile(
 				vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
+				vcc::command::pipeline_barrier(
+					VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+					VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, {}, {},
+					{
+						vcc::command::image_memory_barrier{ 0,
+							VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
+							| VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+							VK_IMAGE_LAYOUT_UNDEFINED,
+							VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+							vcc::queue::get_family_index(present_queue),
+							vcc::queue::get_family_index(queue),
+							swapchain_images[i],
+							{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }
+						}
+					}),
 				vcc::command::render_pass(std::ref(render_pass),
 					vcc::framebuffer::create(std::ref(device), std::ref(render_pass),
 						{
@@ -530,11 +547,26 @@ int main(int argc, const char **argv) {
 						VkViewport{ 0.f, 0.f, float(extent.width), float(extent.height), 0.f, 1.f }
 					} },
 					vcc::command::set_scissor{ 0, { VkRect2D{ VkOffset2D{ 0, 0 }, extent } } },
-					vcc::command::draw_indexed{ (uint32_t)indices.size(), 1, 0, 0, 0 }));
+					vcc::command::draw_indexed{ (uint32_t)indices.size(), 1, 0, 0, 0 }),
+				vcc::command::pipeline_barrier(
+					VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+					VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, {}, {},
+					{
+						vcc::command::image_memory_barrier{
+							VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+							0,
+							VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+							VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+							vcc::queue::get_family_index(queue),
+							vcc::queue::get_family_index(present_queue),
+							swapchain_images[i],
+							{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 } }
+					}));
 			}
 		},
 		[]() {},
-		[&](uint32_t index) {
+		[&](uint32_t index, const vcc::semaphore::semaphore_type &wait_semaphore,
+				const vcc::semaphore::semaphore_type &signal_semaphore) {
 			const glm::mat4 look_at(glm::lookAt(glm::vec3(0, 0, camera_distance),
 			  glm::vec3(0, 0, 0), glm::vec3(0, 1, 0)));
 
@@ -544,7 +576,11 @@ int main(int argc, const char **argv) {
 			type::write(modelview_matrix)[0] = view_matrix;
 			type::write(normal_matrix)[0] =
 				glm::mat3(glm::transpose(glm::inverse(view_matrix)));
-			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
+			vcc::queue::submit(queue,
+				{
+					vcc::queue::wait_semaphore{ std::ref(wait_semaphore),
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT }
+				}, { command_buffers[index] }, { signal_semaphore });
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/sample/teapot/src/teapot.cpp
+++ b/sample/teapot/src/teapot.cpp
@@ -441,11 +441,28 @@ int main(int argc, const char **argv) {
 		vcc::queue::submit(queue, {}, { command_buffer }, {}, fence);
 		vcc::fence::wait(device, { fence }, true);
 
+		const vcc::queue::queue_type &present_queue(vcc::window::get_present_queue(window));
+
 		command_buffers = vcc::command_buffer::allocate(std::ref(device), std::ref(cmd_pool),
 			VK_COMMAND_BUFFER_LEVEL_PRIMARY, (uint32_t) swapchain_images.size());
 		for (std::size_t i = 0; i < swapchain_images.size(); ++i) {
 			vcc::command::compile(
 				vcc::command::build(std::ref(command_buffers[i]), 0, VK_FALSE, 0, 0),
+				vcc::command::pipeline_barrier(
+					VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+					VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, {}, {},
+					{
+						vcc::command::image_memory_barrier{ 0,
+							VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
+							| VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+							VK_IMAGE_LAYOUT_UNDEFINED,
+							VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+							vcc::queue::get_family_index(present_queue),
+							vcc::queue::get_family_index(queue),
+							swapchain_images[i],
+							{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 }
+						}
+					}),
 				vcc::command::render_pass(std::ref(render_pass),
 					vcc::framebuffer::create(std::ref(device), std::ref(render_pass),
 						{
@@ -470,11 +487,26 @@ int main(int argc, const char **argv) {
 						{ VkViewport{ 0.f, 0.f, float(extent.width), float(extent.height), 0.f, 1.f } } },
 					vcc::command::set_scissor{ 0, { VkRect2D{ VkOffset2D{ 0, 0 }, extent } } },
 					vcc::command::draw_indexed{ (uint32_t) teapot::indices.size(),
-						num_instanced_drawings, 0, 0, 0 }));
+						num_instanced_drawings, 0, 0, 0 }),
+				vcc::command::pipeline_barrier(
+					VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+					VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, {}, {},
+					{
+						vcc::command::image_memory_barrier{
+							VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+							0,
+							VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+							VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+							vcc::queue::get_family_index(queue),
+							vcc::queue::get_family_index(present_queue),
+							swapchain_images[i],
+							{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 } }
+					}));
 			}
 		},
 		[]() {},
-		[&](uint32_t index) {
+		[&](uint32_t index, const vcc::semaphore::semaphore_type &wait_semaphore,
+				const vcc::semaphore::semaphore_type &signal_semaphore) {
 			{
 				const glm::mat4 view_matrix(glm::lookAt(glm::vec3(0, 0, camera_distance),
 					glm::vec3(0, 0, 0), glm::vec3(0, 1, 0))
@@ -496,7 +528,11 @@ int main(int argc, const char **argv) {
 						glm::mat3(glm::transpose(glm::inverse(model_view)));
 				}
 			}
-			vcc::queue::submit(queue, {}, { command_buffers[index] }, {});
+			vcc::queue::submit(queue,
+				{
+					vcc::queue::wait_semaphore{ std::ref(wait_semaphore),
+						VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT }
+				}, { command_buffers[index] }, { signal_semaphore });
 		},
 		vcc::window::input_callbacks_type()
 		.set_mouse_down_callback([&](

--- a/vcc/include/vcc/window.h
+++ b/vcc/include/vcc/window.h
@@ -41,7 +41,8 @@ typedef std::function<void(VkFormat)> initialize_callback_type;
 typedef std::function<void(VkExtent2D, VkFormat,
 	std::vector<std::shared_ptr<image::image_type>> &&)> swapchain_create_callback_type;
 typedef std::function<void()> swapchain_destroy_callback_type;
-typedef std::function<void(uint32_t)> draw_callback_type;
+typedef std::function<void(uint32_t, const vcc::semaphore::semaphore_type &,
+	const vcc::semaphore::semaphore_type &)> draw_callback_type;
 
 enum mouse_button_type {
 	mouse_button_left = 0,
@@ -116,19 +117,17 @@ struct window_type {
 		xcb_connection_t *
 #endif
 		);
-	friend std::tuple<swapchain::swapchain_type, std::vector<command_buffer::command_buffer_type>,
-		std::vector<command_buffer::command_buffer_type>> resize(window_type &, VkExtent2D,
+	friend swapchain::swapchain_type resize(window_type &, VkExtent2D,
 			const swapchain_create_callback_type &, const swapchain_destroy_callback_type &,
 			swapchain::swapchain_type &);
-	friend void draw(window_type &window, swapchain::swapchain_type &,
-		std::vector<command_buffer::command_buffer_type> &,
-		std::vector<command_buffer::command_buffer_type> &, vcc::semaphore::semaphore_type &,
+	friend void draw(window_type &, swapchain::swapchain_type &,
 		vcc::semaphore::semaphore_type &, vcc::semaphore::semaphore_type &,
 		const draw_callback_type &, const swapchain_create_callback_type &,
 		const swapchain_destroy_callback_type &, VkExtent2D);
 	friend int run(window_type &, const swapchain_create_callback_type &,
 		const swapchain_destroy_callback_type &, const draw_callback_type &,
 		const input_callbacks_type &);
+	friend const queue::queue_type &get_present_queue(const window_type &);
 
 	window_type() = default;
 	window_type(const window_type&) = delete;
@@ -208,6 +207,10 @@ VCC_LIBRARY int run(window_type &window,
 	const swapchain_destroy_callback_type &swapchain_destroy_callback,
 	const draw_callback_type &draw_callback,
 	const input_callbacks_type &input_callbacks = input_callbacks_type());
+
+inline const queue::queue_type &get_present_queue(const window_type &window) {
+	return window.present_queue;
+}
 
 }  // namespace window
 }  // namespace vcc


### PR DESCRIPTION
It is now the applications responsibility to use an
image_memory_barrier to transition the swapchain to
an appropriate state before drawing as well as transition
the image to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR before returning
from the draw callback.

- Simplifies the pipeline as only one command buffer is executed in render loop.
- queue::wait_idle between present and acquire_next_image fixes a flickering issue
  on Nexus 6P/Nexus 5X (Qualcomm 800 series) devices.