### PR TITLE
Only destroy descriptor_set if owned descriptor_pool allows it.

### DIFF
--- a/vcc/include/vcc/descriptor_pool.h
+++ b/vcc/include/vcc/descriptor_pool.h
@@ -21,9 +21,20 @@
 namespace vcc {
 namespace descriptor_pool {
 
+namespace internal {
+
+template<typename T>
+VkDescriptorPoolCreateFlags get_flags(const T &pool) {
+	return pool.flags;
+}
+
+} // namespace internal
+
 struct descriptor_pool_type
-	: public internal::movable_destructible_with_parent<VkDescriptorPool,
+	: public vcc::internal::movable_destructible_with_parent<VkDescriptorPool,
 		const device::device_type, vkDestroyDescriptorPool> {
+	template<typename T>
+	friend VkDescriptorPoolCreateFlags internal::get_flags(const T &);
 	friend VCC_LIBRARY descriptor_pool_type create(
 		const type::supplier<const device::device_type> &, VkDescriptorPoolCreateFlags, uint32_t,
 		const std::vector<VkDescriptorPoolSize> &);
@@ -36,8 +47,11 @@ struct descriptor_pool_type
 
 private:
 	descriptor_pool_type(VkDescriptorPool instance,
-		const type::supplier<const device::device_type> &parent)
-		: movable_destructible_with_parent(instance, parent) {}
+		const type::supplier<const device::device_type> &parent,
+		VkDescriptorPoolCreateFlags flags)
+		: movable_destructible_with_parent(instance, parent), flags(flags) {}
+
+	VkDescriptorPoolCreateFlags flags;
 };
 
 VCC_LIBRARY descriptor_pool_type create(

--- a/vcc/include/vcc/descriptor_set.h
+++ b/vcc/include/vcc/descriptor_set.h
@@ -45,7 +45,9 @@ struct descriptor_set_type : public internal::movable_allocated_with_pool_parent
 	descriptor_set_type(VkDescriptorSet instance,
 		const type::supplier<const descriptor_pool::descriptor_pool_type> &pool,
 		const type::supplier<const device::device_type> &parent)
-		: movable_allocated_with_pool_parent2(instance, pool, parent) {}
+		: movable_allocated_with_pool_parent2(instance, pool, parent,
+			!!(descriptor_pool::internal::get_flags(*pool)
+				& VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT)) {}
 
 	internal::hook_map_type<std::pair<uint32_t, uint32_t>,
 		util::hash_pair<uint32_t, uint32_t>, const queue::queue_type &> pre_execute_callbacks;

--- a/vcc/include/vcc/internal/raii.h
+++ b/vcc/include/vcc/internal/raii.h
@@ -373,6 +373,7 @@ protected:
 		instance = std::move(copy.instance);
 		pool = std::move(copy.pool);
 		parent = std::move(copy.parent);
+		destructible = copy.destructible;
 	}
 	movable_allocated_with_pool_parent2 &operator=(
 		const movable_allocated_with_pool_parent2 &) = delete;
@@ -383,6 +384,7 @@ protected:
 		instance = std::move(copy.instance);
 		pool = std::move(copy.pool);
 		parent = std::move(copy.parent);
+		destructible = copy.destructible;
 		return *this;
 	}
 
@@ -392,17 +394,18 @@ protected:
 
 	movable_allocated_with_pool_parent2(T instance,
 		const type::supplier<PoolT> &pool,
-		const type::supplier<ParentT> &parent)
-		: instance(instance), pool(pool), parent(parent) {}
+		const type::supplier<ParentT> &parent, bool destructible)
+		: instance(instance), pool(pool), parent(parent), destructible(destructible) {}
 
 private:
 	handle_type<T> instance;
 	type::supplier<PoolT> pool;
 	type::supplier<ParentT> parent;
+	bool destructible;
 	mutable std::mutex mutex;
 
 	void destroy() {
-		if (instance && pool && parent) {
+		if (destructible && instance && pool && parent) {
 			std::lock(internal::get_mutex(*pool), mutex);
 			std::lock_guard<std::mutex> pool_lock(internal::get_mutex(*pool), std::adopt_lock);
 			std::lock_guard<std::mutex> lock(mutex, std::adopt_lock);

--- a/vcc/src/descriptor_pool.cpp
+++ b/vcc/src/descriptor_pool.cpp
@@ -21,16 +21,15 @@ namespace descriptor_pool {
 descriptor_pool_type create(const type::supplier<const device::device_type> &device,
 		VkDescriptorPoolCreateFlags flags, uint32_t maxSets,
 		const std::vector<VkDescriptorPoolSize> &poolSizes) {
-	VkDescriptorPoolCreateInfo create = {
-		VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, NULL};
+	VkDescriptorPoolCreateInfo create = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, NULL};
 	create.flags = flags;
 	create.maxSets = maxSets;
 	create.poolSizeCount = (uint32_t) poolSizes.size();
 	create.pPoolSizes = poolSizes.empty() ? NULL : &poolSizes.front();
 	VkDescriptorPool descriptor_pool;
-	VKCHECK(vkCreateDescriptorPool(internal::get_instance(*device), &create,
-		NULL, &descriptor_pool));
-	return descriptor_pool_type(descriptor_pool, device);
+	VKCHECK(vkCreateDescriptorPool(vcc::internal::get_instance(*device), &create, NULL,
+		&descriptor_pool));
+	return descriptor_pool_type(descriptor_pool, device, flags);
 }
 
 }  // namespace descriptor_pool


### PR DESCRIPTION
If descriptor_pool was created with
VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
the descriptor_set is destroyed when out of scope.
If not, the descriptor_set will be destroyed when both
it and the owning descriptor_pool and its descriptor_sets are
all out of scope.